### PR TITLE
Update browser tab title to say `"acmCSUF | ACM at CSUF"`.

### DIFF
--- a/src/routes/_layout.svelte
+++ b/src/routes/_layout.svelte
@@ -2,7 +2,7 @@
   import Navbar from "../components/sections/navbar.svelte";
   import Footer from "../components/sections/footer.svelte";
   export let segment: string;
-  const pageTitle = segment === undefined ? "home" : segment;
+  const pageTitle = segment === undefined ? "ACM at CSUF" : segment;
 </script>
 
 <Navbar segment="{segment}" />


### PR DESCRIPTION
I updated the text that is displayed on the site's browser tab to say `"acmCSUF | ACM at CSUF"` if on the home page.