### PR TITLE
Added the `acm-paths.svelte` section

### DIFF
--- a/src/components/sections/acm-paths.svelte
+++ b/src/components/sections/acm-paths.svelte
@@ -1,0 +1,75 @@
+<script lang="ts">
+  import { acmPaths } from "../../lib/acm-paths";
+  import { styleProps } from "../../actions/use-style-props";
+</script>
+
+<section>
+  <div class="paths-intro">
+    <h2>get involved with our paths!</h2>
+    <p>
+      Want to specialize somewhere specific in tech? Our paths were designed to
+      give students a head start in their own tech journeys, making them
+      prepared for the industry.
+    </p>
+  </div>
+
+  <div class="paths-list">
+    {#each acmPaths as { title, slug, picture, color } (slug)}
+      <a class="path-item" href="{`/paths#${slug}`}">
+        <img src="{picture}" alt="{`${slug}-logo`}" />
+        <p>
+          acm<span use:styleProps="{{ 'brand-color': color }}">{title}</span>
+        </p>
+      </a>
+    {/each}
+  </div>
+</section>
+
+<style>
+  .paths-intro {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+  }
+
+  .paths-intro h2 {
+    font-size: 3rem;
+    text-align: center;
+    margin: 0 1em 1em 1em;
+  }
+
+  .paths-intro p {
+    text-align: center;
+    font-size: 2rem;
+    max-width: 50vw;
+  }
+
+  .paths-list {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+  }
+
+  .path-item {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    text-decoration: none;
+    padding: 5em 0 0 0;
+  }
+
+  .path-item img {
+    width: 250px;
+    height: 250px;
+  }
+
+  .path-item p {
+    font-size: var(--max-p-font-size);
+    font-weight: 700;
+    text-decoration: none;
+  }
+
+  .path-item p span {
+    color: var(--brand-color);
+  }
+</style>

--- a/src/components/sections/spacing.svelte
+++ b/src/components/sections/spacing.svelte
@@ -1,0 +1,12 @@
+<script lang="ts">
+  import { styleProps } from "../../actions/use-style-props";
+  export let amount: string = "100px";
+</script>
+
+<div use:styleProps="{{ 'spacing-height': amount }}"></div>
+
+<style>
+  div {
+    height: var(--spacing-height);
+  }
+</style>

--- a/src/components/ui/call-to-action.svelte
+++ b/src/components/ui/call-to-action.svelte
@@ -10,13 +10,13 @@
     cursor: pointer;
     border-radius: 25px;
     background-color: var(--acm-dark);
-    padding: 16px 8px 16px 8px;
+    padding: 8px 16px 8px 16px;
+    margin-top: 24px;
     font-weight: bold;
     color: var(--acm-light);
     text-decoration: none;
     border: 2px solid var(--acm-dark);
     font-size: 1rem;
-    padding: 1em;
     text-transform: lowercase;
   }
 

--- a/src/lib/acm-paths.ts
+++ b/src/lib/acm-paths.ts
@@ -1,0 +1,32 @@
+interface AcmPath {
+  title: string;
+  slug: string;
+  picture: string;
+  color: string;
+}
+
+const acmAlgo: AcmPath = {
+  title: "Algo",
+  slug: "acmalgo",
+  picture: "./assets/png/acm-algo-badge.png",
+  color: "var(--acm-purple)",
+};
+
+const acmCreate: AcmPath = {
+  title:"Create",
+  slug:"acmcreate",
+  picture: "./assets/png/acm-create-badge.png",
+  color: "var(--acm-pink)"
+};
+
+const acmDev: AcmPath = {
+  title: "Dev",
+  slug: "acmdev",
+  picture: "./assets/png/acm-dev-badge.png",
+  color: "var(--acm-bluer)"
+};
+
+
+export const acmPaths = [
+  acmAlgo, acmCreate, acmDev
+] as const;

--- a/src/routes/index.svelte
+++ b/src/routes/index.svelte
@@ -54,89 +54,109 @@
 <style lang="scss">
   @import "../style/theme.scss";
 
+  @media screen and (max-width: 768px) {
+  }
+
   .screen-paths {
     width: 100%;
     display: flex;
     flex-direction: column;
     align-items: center;
     justify-content: center;
-
-    .paths-intro {
-      padding-top: 333px;
-      padding-bottom: 64px;
-      display: flex;
-      flex-direction: column;
-      align-items: center;
-      justify-content: center;
-
-      h2 {
-        margin: 0;
-        @include fluidSize($minHFontSize, $maxHFontSizeMed);
-        @include fluidSize(10, 32, $propName: "padding-bottom");
-        text-align: center;
-        font-weight: bold;
-      }
-      p {
-        @include fluidSize($minPFontSize, $maxPFontSize);
-        @include fluidSize(190, 1310, $propName: "width");
-        @include fluidSize(18, 54, $propName: "line-height");
-        margin: 0;
-        align-content: center;
-        text-align: center;
-      }
-    }
-    .paths-display {
-      display: flex;
-      flex-direction: row;
-      justify-content: space-evenly;
-      align-items: center;
-
-      .path-item {
-        display: flex;
-        flex-direction: column;
-        align-items: center;
-        justify-content: center;
-        color: $acmDark;
-        text-decoration: none;
-
-        object {
-          @include fluidSize(36, 250, $propName: "width");
-          @include fluidSize(36, 250, $propName: "height");
-        }
-        span {
-          @include fluidSize(18, 36);
-        }
-      }
-    }
-    @media screen and (max-width: $breakpoint) {
-      .paths-display {
-        flex-direction: column;
-        .path-item {
-          padding-top: 1em;
-        }
-      }
-    }
   }
 
-  .screen-node-buds {
-    background: 10% 50% no-repeat url(../assets/badges/acm-blank.svg);
+  .screen-path .paths-intro {
+    padding-top: 333px;
+    padding-bottom: 64px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+  }
 
-    div {
-      @include fluidSize(10, 128, $propName: "padding-right");
-      padding-top: 333px;
-      h2 {
-        @include fluidSize($minHFontSize, $maxHFontSizeMed);
-        @include fluidSize(10, 32, $propName: "padding-bottom");
-        font-weight: bold;
-        text-align: right;
-        margin: 0;
+  .screen-path .paths-intro h2 {
+    margin: 0;
+    font-size: var(--min-p-font-size);
+    padding-bottom: 10;
+    @include fluidSize($minHFontSize, $maxHFontSizeMed);
+    @include fluidSize(10, 32, $propName: "padding-bottom");
+    text-align: center;
+    font-weight: bold;
+  }
+
+  .screen-path .paths-intro p {
+    font-size: var(--min-p-font-size);
+    width: 190px;
+    line-height: 18px;
+    margin: 0;
+    align-content: center;
+    text-align: center;
+  }
+
+  .screen-path .paths-display {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-evenly;
+    align-items: center;
+  }
+
+  .screen-path .paths-display .path-item {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    color: $acmDark;
+    text-decoration: none;
+
+    .screen-path .paths-display .path-item object {
+      @include fluidSize(36, 250, $propName: "width");
+      @include fluidSize(36, 250, $propName: "height");
+    }
+    .screen-path .paths-display .path-item span {
+      @include fluidSize(18, 36);
+    }
+
+    @media screen and (max-width: 768px) {
+      .screen-path .paths-intro h2 {
+        font-size: var(--max-h-font-size-med);
+        padding-bottom: 32px;
       }
-      p {
-        @include fluidSize($minPFontSize, $maxPFontSize);
-        @include fluidSize(150, 1014, $propName: "width");
-        text-align: right;
-        float: right;
-        margin: 0;
+
+      .screen-path .paths-intro p {
+        font-size: var(--max-p-font-size);
+        width: 1310px;
+        line-height: 54px;
+      }
+
+      .screen-path .paths-display {
+        flex-direction: column;
+      }
+
+      .screen-path .paths-display .path-item {
+        padding-top: 1em;
+      }
+    }
+
+    .screen-node-buds {
+      background: 10% 50% no-repeat url(../assets/badges/acm-blank.svg);
+
+      div {
+        @include fluidSize(10, 128, $propName: "padding-right");
+        padding-top: 333px;
+        h2 {
+          @include fluidSize($minHFontSize, $maxHFontSizeMed);
+          @include fluidSize(10, 32, $propName: "padding-bottom");
+          font-weight: bold;
+          text-align: right;
+          margin: 0;
+        }
+        p {
+          @include fluidSize($minPFontSize, $maxPFontSize);
+          @include fluidSize(150, 1014, $propName: "width");
+          text-align: right;
+          float: right;
+          margin: 0;
+        }
       }
     }
   }

--- a/src/routes/index.svelte
+++ b/src/routes/index.svelte
@@ -1,163 +1,17 @@
 <script>
   import Hero from "@/components/sections/hero.svelte";
   import WhyJoin from "@/components/sections/why-join.svelte";
+  import AcmPaths from "@/components/sections/acm-paths.svelte";
   import WhatAreYouWaitingFor from "@/components/sections/what-are-you-waiting-for.svelte";
+  import Spacing from "@/components/sections/spacing.svelte";
 </script>
 
+<Spacing />
 <Hero />
+<Spacing />
 <WhyJoin />
-
-<section class="info-screen screen-paths">
-  <div>
-    <div class="paths-intro">
-      <h2><span class="headers">get involved with our paths!</span></h2>
-      <p>
-        Want to specialize somewhere specific in tech? Our paths were designed
-        to give students a head start in their own tech journeys, making them
-        prepared for the industry.
-      </p>
-    </div>
-    <div class="paths-display">
-      <a class="path-item" href="/paths#acm-algo">
-        <object
-          type="image/svg+xml"
-          data="assets/badges/with-shadow/acm-algo-badge-s.svg"
-          title="acm-algo-logo"></object>
-        <span class="headers"
-          >acm<span class="brand-purple brand-em">Algo</span>
-        </span></a
-      >
-      <a class="path-item" href="/paths#acm-create">
-        <object
-          type="image/svg+xml"
-          data="assets/badges/with-shadow/acm-create-badge-s.svg"
-          title="acm-create-logo"></object>
-        <span class="headers"
-          >acm<span class="brand-pink brand-em">Create</span>
-        </span>
-      </a>
-      <a class="path-item" href="/paths#acm-dev">
-        <object
-          type="image/svg+xml"
-          data="assets/badges/with-shadow/acm-dev-badge-s.svg"
-          title="acm-dev-logo"></object>
-        <span class="headers"
-          >acm<span class="brand-bluer brand-em">Dev</span>
-        </span>
-      </a>
-    </div>
-  </div>
-</section>
-
+<Spacing />
+<AcmPaths />
+<Spacing />
 <WhatAreYouWaitingFor />
-
-<style lang="scss">
-  @import "../style/theme.scss";
-
-  @media screen and (max-width: 768px) {
-  }
-
-  .screen-paths {
-    width: 100%;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    justify-content: center;
-  }
-
-  .screen-path .paths-intro {
-    padding-top: 333px;
-    padding-bottom: 64px;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    justify-content: center;
-  }
-
-  .screen-path .paths-intro h2 {
-    margin: 0;
-    font-size: var(--min-p-font-size);
-    padding-bottom: 10;
-    @include fluidSize($minHFontSize, $maxHFontSizeMed);
-    @include fluidSize(10, 32, $propName: "padding-bottom");
-    text-align: center;
-    font-weight: bold;
-  }
-
-  .screen-path .paths-intro p {
-    font-size: var(--min-p-font-size);
-    width: 190px;
-    line-height: 18px;
-    margin: 0;
-    align-content: center;
-    text-align: center;
-  }
-
-  .screen-path .paths-display {
-    display: flex;
-    flex-direction: row;
-    justify-content: space-evenly;
-    align-items: center;
-  }
-
-  .screen-path .paths-display .path-item {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    justify-content: center;
-    color: $acmDark;
-    text-decoration: none;
-
-    .screen-path .paths-display .path-item object {
-      @include fluidSize(36, 250, $propName: "width");
-      @include fluidSize(36, 250, $propName: "height");
-    }
-    .screen-path .paths-display .path-item span {
-      @include fluidSize(18, 36);
-    }
-
-    @media screen and (max-width: 768px) {
-      .screen-path .paths-intro h2 {
-        font-size: var(--max-h-font-size-med);
-        padding-bottom: 32px;
-      }
-
-      .screen-path .paths-intro p {
-        font-size: var(--max-p-font-size);
-        width: 1310px;
-        line-height: 54px;
-      }
-
-      .screen-path .paths-display {
-        flex-direction: column;
-      }
-
-      .screen-path .paths-display .path-item {
-        padding-top: 1em;
-      }
-    }
-
-    .screen-node-buds {
-      background: 10% 50% no-repeat url(../assets/badges/acm-blank.svg);
-
-      div {
-        @include fluidSize(10, 128, $propName: "padding-right");
-        padding-top: 333px;
-        h2 {
-          @include fluidSize($minHFontSize, $maxHFontSizeMed);
-          @include fluidSize(10, 32, $propName: "padding-bottom");
-          font-weight: bold;
-          text-align: right;
-          margin: 0;
-        }
-        p {
-          @include fluidSize($minPFontSize, $maxPFontSize);
-          @include fluidSize(150, 1014, $propName: "width");
-          text-align: right;
-          float: right;
-          margin: 0;
-        }
-      }
-    }
-  }
-</style>
+<Spacing />

--- a/src/routes/paths/index.svelte
+++ b/src/routes/paths/index.svelte
@@ -1,26 +1,19 @@
 <script lang="ts">
-  import Headline from "../../components/sections/headline.svelte";
+  import CommonHero from "../../components/sections/common-hero.svelte";
   import WhatAreYouWaitingFor from "../../components/sections/what-are-you-waiting-for.svelte";
 </script>
 
-<section class="paths-screen-hero">
-  <div>
-    <Headline>paths</Headline>
-    <div class="about-description-container">
-      <h2 class="brand-em">
-        <span class="brand-em">what are paths?</span>
-      </h2>
-      <p>
-        <span class="brand-em">paths</span> are committees that focus on certain
-        areas related to the industry. students can discover new interests,
-        enhance current skillsets, and specialize in specific fields through
-        these committees. <span class="brand-em">paths</span> were designed to encourage
-        teamwork and communication to prepare people for real-world opportunities
-        in tech.
-      </p>
-    </div>
-  </div>
-</section>
+<CommonHero>
+  <h1 slot="title">paths</h1>
+  <h2 slot="headline">what are paths?</h2>
+  <p slot="text">
+    <span class="brand-em">paths</span> are committees that focus on certain
+    areas related to the industry. students can discover new interests, enhance
+    current skillsets, and specialize in specific fields through these
+    committees. <span class="brand-em">paths</span> were designed to encourage teamwork
+    and communication to prepare people for real-world opportunities in tech.
+  </p>
+</CommonHero>
 
 <section class="paths-screen-info turnback">
   <div id="acm-algo">
@@ -98,6 +91,7 @@
           @include fluidSize($minHFontSize, $maxHFontSizeMed);
           text-align: center;
           font-weight: bold;
+          padding-bottom: 48px;
         }
         p {
           @include fluidSize($minPFontSize, $maxPFontSize);
@@ -115,6 +109,9 @@
       justify-content: space-around;
       align-items: center;
       padding-top: 100px;
+      h2 {
+        padding-bottom: 48px;
+      }
 
       &:nth-child(even) {
         flex-flow: row-reverse;

--- a/src/routes/paths/index.svelte
+++ b/src/routes/paths/index.svelte
@@ -26,7 +26,7 @@
   <div id="acm-algo">
     <object
       type="image/png"
-      data="../assets/badges/PNG/acm-algo-badge.png"
+      data="../assets/png/acm-algo-badge.png"
       title="acm-algo-logo"></object>
     <div>
       <h2>
@@ -44,7 +44,7 @@
   <div id="acm-create">
     <object
       type="image/png"
-      data="../assets/badges/PNG/acm-create-badge.png"
+      data="../assets/png/acm-create-badge.png"
       title="acm-create-logo"></object>
     <div>
       <h2>
@@ -62,7 +62,7 @@
   <div id="acm-dev">
     <object
       type="image/png"
-      data="../assets/badges/PNG/acm-dev-badge.png"
+      data="../assets/png/acm-dev-badge.png"
       title="acm-dev-logo"></object>
     <div>
       <h2>

--- a/static/global.css
+++ b/static/global.css
@@ -23,5 +23,12 @@ body,
   --acm-red: #c40042;
   --acm-dark: #212121;
   --acm-light: #ffffff;
+
   --desktop-breakpoint: 768px;
+
+  --min-p-font-size: 18px;
+  --max-p-font-size: 36px;
+  --min-h-font-size: 22px;
+  --max-h-font-size: 86px;
+  --max-h-font-size-med: 64px;
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,8 @@
   "include": ["src/**/*", "src/node_modules/**/*"],
   "exclude": ["node_modules/*", "__sapper__/*", "static/*"],
   "paths": {
-    "@components": "./src/components/"
+    "@/components*": "./src/components/",
+    "@/lib*": "./src/lib/",
+    "@/actions*": "./src/actions/"
   }
 }


### PR DESCRIPTION
Right now, it is rendered in mobile mode only. The [`acm-paths.svelte` component](https://github.com/EthanThatOneKid/acmcsuf.com/blob/main/src/components/sections/acm-paths.svelte) can easily be updated for the desktop layout at a later date.