### PR TITLE
Fix nodeBuds paragraph alignment, turnback class

### DIFF
--- a/src/components/sections/why-join-nodebuds.svelte
+++ b/src/components/sections/why-join-nodebuds.svelte
@@ -1,82 +1,89 @@
-<div class="turnback">
-  <div class="why-join-nodebuds">
-    <!-- <img src="../assets/png/why-join-node-buds-illustration.png" alt="" /> -->
-
-    <object
-      type="image/png"
-      data="../assets/png/why-join-node-buds-illustration.png"
-      title="Why Join nodeBuds"></object>
-    <div>
-      <h2>why join node<span class="brand-red">buds</span>?</h2>
-      <p>
-        <span class="brand-em">node<span class="brand-red">Buds</span></span>
-        was designed to provide underclassmen and transfer students assistance as
-        they start their fresh journey through
-        <span class="brand-blue brand-em">CSUF</span>, and through the tech
-        industry. We provide the knowledge and resources that’ll help students
-        start on the right foot.
-      </p>
-    </div>
+<div id="why-join-nodebuds">
+  <img
+    src="../assets/png/why-join-node-buds-illustration.png"
+    alt="Why Join nodeBuds"
+    title="Why Join nodeBuds"
+  />
+  <div class="turnback">
+    <h2>why join node<span class="brand-red">Buds</span>?</h2>
+    <p>
+      <span class="brand-em">node<span class="brand-red">Buds</span></span>
+      was designed to provide underclassmen and transfer students assistance as they
+      start their fresh journey through
+      <span class="brand-blue brand-em">CSUF</span>, and through the tech
+      industry. We provide the knowledge and resources that’ll help students
+      start on the right foot.
+    </p>
   </div>
 </div>
 
-<style lang="scss">
-  @import "../../style/theme.scss";
+<style>
+  #why-join-nodebuds {
+    display: flex;
+    flex-direction: row;
 
+    align-items: center;
+    justify-content: space-around;
+
+    margin: auto; /* center */
+    padding: 4em 2em;
+  }
+
+  /* Make the image take over a bit more than half at full size. */
+  #why-join-nodebuds > img {
+    width: 55%;
+  }
+  /* Fill the rest with the text box. */
+  #why-join-nodebuds > .turnback {
+    flex: 1;
+  }
+
+  /* Magic title flipping - "turnback".
+   * TODO: this could be copy-pasted into global.css. */
   .turnback {
-    div {
-      display: flex;
-      flex-direction: row;
-      justify-content: space-around;
+    display: flex;
+    flex-direction: column;
+
+    font-size: var(--fluid-font-size);
+    padding-left: 2em;
+    padding-right: 2em;
+
+    align-items: flex-start; /* account for short texts */
+    text-align: left; /* account for multi-line texts */
+  }
+  .turnback:nth-child(even) {
+    align-items: flex-end;
+    text-align: right;
+  }
+
+  .turnback > p {
+    font-size: var(--p-font-size);
+  }
+  .turnback > h2 {
+    font-size: var(--h-font-size-med);
+    font-weight: 600; /* medium, not bold */
+  }
+
+  /* Mobile view */
+  @media screen and (max-width: 1440px) {
+    #why-join-nodebuds {
+      flex-direction: column;
+    }
+
+    #why-join-nodebuds > img {
+      width: max(55vw, 550px);
+      max-width: 100%;
+    }
+    #why-join-nodebuds > .turnback > p {
+      max-width: max(30vw, 300px);
+    }
+
+    .turnback,
+    .turnback:nth-child(even) {
       align-items: center;
-      padding: 4em 2em 0;
+      text-align: center;
 
-      &:nth-child(even) {
-        flex-flow: row-reverse;
-        div {
-          align-items: flex-start;
-          p {
-            text-align: left;
-          }
-        }
-      }
-
-      @media screen and (max-width: 1440px) {
-        flex-direction: column;
-        align-items: center;
-        flex-flow: column !important;
-        div {
-          justify-content: center;
-          align-items: center;
-          p,
-          h2 {
-            width: 100%;
-            text-align: center !important;
-          }
-        }
-      }
-
-      object {
-        @include fluidSize(237, 932, $propName: "width");
-        @include fluidSize(80, 314, $propName: "height");
-      }
-      div {
-        display: flex;
-        flex-direction: column;
-        justify-content: center;
-        align-items: flex-end;
-        flex-flow: column !important;
-        h2 {
-          @include fluidSize($minHFontSize, $maxHFontSizeMed);
-          text-align: center;
-          font-weight: bold;
-        }
-        p {
-          @include fluidSize($minPFontSize, $maxPFontSize);
-          @include fluidSize(150, 800, $propName: "width");
-          text-align: right;
-        }
-      }
+      padding-top: 4em;
     }
   }
 </style>

--- a/static/global.css
+++ b/static/global.css
@@ -26,9 +26,54 @@ body,
 
   --desktop-breakpoint: 768px;
 
+  /* Fluid font size is the magical numbers for fluid font sizing. It should be
+   * put into parent containers. */
+  --fluid-font-size: clamp(1vw, 0.7em, 3vw);
+
+  --p-font-size: 2em;
+  --h-font-size-med: 3em;
+
   --min-p-font-size: 18px;
   --max-p-font-size: 36px;
   --min-h-font-size: 22px;
   --max-h-font-size: 86px;
   --max-h-font-size-med: 64px;
+}
+
+/* Branding Macros */
+.brand-em {
+  /* `em` is short for "emphasis" */
+  font-weight: 700;
+}
+
+.headers {
+  font-weight: 600;
+}
+
+.brand-blue {
+  color: var(--acm-blue);
+}
+
+.brand-bluer {
+  color: var(--acm-bluer);
+}
+
+.brand-pink {
+  color: var(--acm-pink);
+}
+
+.brand-purple {
+  color: var(--acm-purple);
+}
+
+.brand-red {
+  color: var(--acm-red);
+}
+
+.brand-dark {
+  color: var(--acm-dark);
+}
+
+.brand-light {
+  color: var(--acm-light);
 }


### PR DESCRIPTION
    Fix nodeBuds paragraph alignment, turnback class
    
    This commit fixes the second paragraph's alignment in mobile view to
    render properly. It also fixes a minor capitalization error ("nodebuds"
    to "nodeBuds").
    
    This commit also adds the groundwork for potential future refactoring:
    the CSS variables --fluid-font-size, --p-font-size and --h-font-size-med
    were introduced to slowly replace the previous fluidSize mixin.
    
    The --fluid-font-size uses the CSS clamp() math function to achieve
    smoothly scalable font sizes across all viewports unlike setting manual
    font-sizes over @media. This behavior is almost similar to the mixin.
    Its intended use case is to be set at the parent container (or the
    body). Note that this affects the margins and paddings if they use em as
    well.
    
    The two new font size variables, --p-font-size and --h-font-size-med,
    are in em units to properly utilize the above --fluid-font-size set in
    the parent container. The em units will scale accordingly. This is
    different from using px, which is scaled absolutely (as opposed to
    relatively to the parent's font-size).

---

This PR closes #49.

Certain note-worthy things:

1. The old `<div class="turnback">` that wraps everything is removed.
2. `<div class="turnback">` is only used to wrap the text paragraph now.
3. `.turnback` CSS code should be OK to be copy-pasted into `global.css` once other components remove its own (probably).



