### PR TITLE
Getting some final touches in before launching `/nodebuds`!

### DIFF
--- a/src/components/nodebuds/nodebuds-testimonial.svelte
+++ b/src/components/nodebuds/nodebuds-testimonial.svelte
@@ -22,19 +22,19 @@
   }
 
   .info-container {
-    max-width: 55vw;
-    margin-bottom: 2em;
+    max-width: 55vw; /* Here, max-width is being used to keep the text from overtaking the image's visual hierarchy. */
     font-size: var(--fluid-font-size);
     text-align: center;
   }
 
   .info-container :global(h2) {
-    font-size: var(--h-font-size-med);
-    margin-bottom: 1em;
+    font-size: var(--heading-font-size);
+    margin-bottom: 20px;
+    hyphens: auto; /* Read: https://css-tricks.com/almanac/properties/h/hyphenate/ */
   }
 
   .info-container :global(p) {
-    font-size: var(--p-font-size);
+    font-size: var(--body-font-size);
   }
 
   .image-container img {
@@ -47,7 +47,7 @@
       flex-direction: row;
       align-items: center;
       justify-content: space-around;
-      padding: 0 2em;
+      padding: 0 20px;
     }
 
     .info-container {

--- a/src/components/nodebuds/why-join-nodebuds.svelte
+++ b/src/components/nodebuds/why-join-nodebuds.svelte
@@ -44,7 +44,6 @@
     display: flex;
     flex-direction: column;
 
-    font-size: var(--fluid-font-size);
     padding-left: 2em;
     padding-right: 2em;
 
@@ -57,10 +56,10 @@
   }
 
   .turnback > p {
-    font-size: var(--p-font-size);
+    font-size: var(--body-font-size);
   }
   .turnback > h2 {
-    font-size: var(--h-font-size-med);
+    font-size: var(--heading-font-size);
     font-weight: 600; /* medium, not bold */
   }
 

--- a/src/components/sections/navbar.svelte
+++ b/src/components/sections/navbar.svelte
@@ -4,7 +4,7 @@
     { title: "about", slug: "about" },
     // { title: "events", slug: "events" },
     { title: "paths", slug: "paths" },
-    // { title: "nodeBuds", slug: "node-buds" },
+    { title: "nodeBuds", slug: "nodebuds" },
     // { title: "connect", slug: "connect" },
     // { title: "newsletters", slug: "posts" },
   ];


### PR DESCRIPTION
The launch of `/nodebuds` is coming up, so these changes are to be considered the final touches before the official launch which will occur at meeting #59. These changes were made with respect to the notes within issue #61.

What happened here:

- For all [`/nodebud`-specific components](https://github.com/EthanThatOneKid/acmcsuf.com/blob/main/src/components/nodebuds/), I implemented our new CSS variables to uniformly assign font sizing to all text elements on the page.
- Added some minor changes/notes to the layout.