### PR TITLE
Added Google Form option for the `/connect` page

### DIFF
--- a/src/components/sections/get-in-touch-form.svelte
+++ b/src/components/sections/get-in-touch-form.svelte
@@ -1,5 +1,10 @@
 <script lang="ts">
-  export let googleFormUrl: string | undefined = undefined;
+  export let googleFormId: string | undefined = undefined;
+  let googleFormUrl: string | undefined = undefined;
+
+  if (googleFormId !== undefined) {
+    googleFormUrl = `https://docs.google.com/forms/d/e/${googleFormId}/viewform?embedded=true`;
+  }
 </script>
 
 <section>

--- a/src/components/sections/get-in-touch-form.svelte
+++ b/src/components/sections/get-in-touch-form.svelte
@@ -1,4 +1,8 @@
-<section id="Get-In-Touch-Section">
+<script lang="ts">
+  export let googleFormUrl: string | undefined = undefined;
+</script>
+
+<section>
   <h2>Get in touch</h2>
   <p>
     Have any questions for us? Want to work with us? Just want to say hi?
@@ -6,61 +10,76 @@
     form below, and we’ll have a representative get back to you as soon as
     possible. Don’t worry, we’re friendly! 😊
   </p>
-  <form id="Contact-Form" action="#">
-    <formfield>
-      <label for="form-name"></label>
+  {#if googleFormUrl === undefined}
+    <form action="#">
+      <formfield>
+        <label for="form-name"></label>
+        <input
+          type="text"
+          id="form-name"
+          name="form-name"
+          placeholder="name*"
+          required
+        />
+        <label for="form-email"></label>
+        <input
+          type="text"
+          id="form-email"
+          name="form-email"
+          placeholder="email*"
+          required
+        />
+      </formfield>
+      <label for="form-topic"></label>
       <input
         type="text"
-        id="form-name"
+        id="form-topic"
+        name="form-topic"
+        placeholder="topic*"
+        required
+      />
+      <label for="form-message"></label>
+      <textarea
+        type="text"
+        id="form-topic"
         name="form-name"
-        placeholder="name*"
-        required
-      />
-      <label for="form-email"></label>
-      <input
-        type="text"
-        id="form-email"
-        name="form-email"
-        placeholder="email*"
-        required
-      />
-    </formfield>
-    <label for="form-topic"></label>
-    <input
-      type="text"
-      id="form-topic"
-      name="form-topic"
-      placeholder="topic*"
-      required
-    />
-    <label for="form-message"></label>
-    <textarea
-      type="text"
-      id="form-topic"
-      name="form-name"
-      placeholder="message*"
-      required></textarea>
-  </form>
+        placeholder="message*"
+        required></textarea>
+    </form>
+  {:else}
+    <iframe
+      src="{googleFormUrl}"
+      title="acmCSUF contact form"
+      width="700"
+      height="520"
+      frameborder="0"
+      marginheight="0"
+      marginwidth="0"
+    >
+      Loading…
+    </iframe>
+  {/if}
 </section>
 
 <style>
-  #Get-In-Touch-Section {
+  section {
     display: flex;
     flex-direction: column;
     align-items: center;
     justify-content: center;
   }
 
-  #Get-In-Touch-Section :global(h2) {
+  section :global(h2) {
     font-size: var(--subheading-font-size);
   }
 
-  #Get-In-Touch-Section :global(p) {
+  section :global(p) {
     font-size: var(--body-font-size);
     text-align: center;
     margin: 0 3rem;
   }
-  #Contact-Form {
+
+  form {
     display: flex;
     flex-direction: column;
     width: 80%;
@@ -71,8 +90,9 @@
     display: flex;
     flex-direction: column;
   }
-  #Contact-Form input[type="text"],
-  #Contact-Form textarea {
+
+  form input[type="text"],
+  form textarea {
     background-color: var(--acm-light);
     border-radius: 25px;
     font-size: var(--body-font-size);
@@ -81,7 +101,8 @@
     box-shadow: 0 6px 9px rgba(55, 146, 193, 0.5);
     border: none;
   }
-  #Contact-Form textarea {
+
+  form textarea {
     resize: none;
   }
 
@@ -91,6 +112,7 @@
       display: flex;
       flex-direction: row;
     }
+
     formfield input {
       flex-grow: 1;
     }

--- a/src/components/sections/get-in-touch-form.svelte
+++ b/src/components/sections/get-in-touch-form.svelte
@@ -50,8 +50,8 @@
     <iframe
       src="{googleFormUrl}"
       title="acmCSUF contact form"
-      width="700"
-      height="520"
+      width="100%"
+      height="1024"
       frameborder="0"
       marginheight="0"
       marginwidth="0"
@@ -76,7 +76,7 @@
   section :global(p) {
     font-size: var(--body-font-size);
     text-align: center;
-    margin: 0 3rem;
+    margin: 2rem 3rem;
   }
 
   form {

--- a/src/routes/connect.svelte
+++ b/src/routes/connect.svelte
@@ -4,6 +4,8 @@
   import SocialMediaLinks from "@/components/sections/social-media-links.svelte";
   import GetInTouchForm from "@/components/sections/get-in-touch-form.svelte";
   import CallToActionSection from "@/components/sections/call-to-action-section.svelte";
+
+  const googleFormUrl = `https://docs.google.com/forms/d/e/1FAIpQLSfJanOAaL2mdjpf193tFeCClBzpW_COEO_crAE8hqsJCB_Rwg/viewform?embedded=true`;
 </script>
 
 <CommonHero src="../assets/png/acm-csuf-badge.png" alt="acm-CSUF-Logo">
@@ -18,7 +20,7 @@
 </CommonHero>
 <SocialMediaLinks />
 <Spacing />
-<GetInTouchForm />
+<GetInTouchForm googleFormUrl="{googleFormUrl}" />
 <Spacing />
 <CallToActionSection>
   <h2 slot="headline">so what are you waiting for?</h2>

--- a/src/routes/connect.svelte
+++ b/src/routes/connect.svelte
@@ -5,7 +5,8 @@
   import GetInTouchForm from "@/components/sections/get-in-touch-form.svelte";
   import CallToActionSection from "@/components/sections/call-to-action-section.svelte";
 
-  const googleFormUrl = `https://docs.google.com/forms/d/e/1FAIpQLSfJanOAaL2mdjpf193tFeCClBzpW_COEO_crAE8hqsJCB_Rwg/viewform?embedded=true`;
+  const googleFormId =
+    "1FAIpQLSfJanOAaL2mdjpf193tFeCClBzpW_COEO_crAE8hqsJCB_Rwg";
 </script>
 
 <CommonHero src="../assets/png/acm-csuf-badge.png" alt="acm-CSUF-Logo">
@@ -20,7 +21,7 @@
 </CommonHero>
 <SocialMediaLinks />
 <Spacing />
-<GetInTouchForm googleFormUrl="{googleFormUrl}" />
+<GetInTouchForm googleFormId="{googleFormId}" />
 <Spacing />
 <CallToActionSection>
   <h2 slot="headline">so what are you waiting for?</h2>


### PR DESCRIPTION
I was not able to get access to acmCSUF's official MailChimp account, so we cannot use the HTML form that is shown in the design currently. Once we get access to the MailChimp account, we can easily go back to the HTML form that @bjwarfield created!

TL;DR: As a temporary alternative, we are embedding a Google Form.