### PR TITLE
Fixed up the hero image's weird spacing on mobile

### DIFF
--- a/src/components/index/hero.svelte
+++ b/src/components/index/hero.svelte
@@ -13,12 +13,10 @@
       link="https://tinyurl.com/acm-csuf-discord/"
     />
   </div>
-  <figure>
-    <img
-      src="/assets/png/hero-illustration.png"
-      alt="Frank the shark (ACM CSUF's mascot) is holding a flag that says 'I ♥ ACM'"
-    />
-  </figure>
+  <img
+    src="/assets/png/hero-illustration.png"
+    alt="Frank the shark (ACM CSUF's mascot) is holding a flag that says 'I ♥ ACM'"
+  />
 </section>
 
 <style>
@@ -43,14 +41,7 @@
     margin: 0 24px;
   }
 
-  section figure {
-    display: flex;
-    margin: 0 auto;
-    margin-inline-start: 0; /* Reset default styling */
-    margin-inline-end: 0; /* Reset default styling */
-  }
-
-  section figure img {
+  section img {
     width: 270px;
     margin-left: -2rem;
     object-fit: contain;
@@ -81,9 +72,8 @@
       margin: 0;
     }
 
-    section figure img {
+    section img {
       width: 540px;
-      margin-left: -2rem;
     }
   }
 </style>


### PR DESCRIPTION
I removed the `<figure>` element that was wrapping the image. This might have been the cause of the odd spacing shown on my mobile device.

After checking [the preview](https://vercel.com/ethanthatonekid/acm-csuf-site/2GShnUAhsEB3MF9EmX855v2QfgEv) on my mobile device, I can say that the `<figure>` element was probably the cause of the unneeded spacing. This resolves issue #82!