### PR TITLE
Fix our contact Google Form's height 📐

### DIFF
--- a/src/components/sections/get-in-touch-form.svelte
+++ b/src/components/sections/get-in-touch-form.svelte
@@ -56,7 +56,7 @@
       src="{googleFormUrl}"
       title="acmCSUF contact form"
       width="100%"
-      height="1024"
+      height="520"
       frameborder="0"
       marginheight="0"
       marginwidth="0"


### PR DESCRIPTION
Updated `get-in-touch-form.svelte` with the recommended embedded-Google Form height which happens to be `520px`.