### PR TITLE
Updated `acm-button.svelte` component styling

### DIFF
--- a/src/components/utils/acm-button.svelte
+++ b/src/components/utils/acm-button.svelte
@@ -12,20 +12,25 @@
     cursor: pointer;
     border-radius: 15px;
     user-select: none;
-    background-color: var(--acm-dark);
+    background-color: none;
     padding: 8px 16px 8px 16px;
     margin-top: 24px;
     font-weight: bold;
-    color: var(--acm-light);
+    color: var(--acm-dark);
     text-decoration: none;
     border: 2px solid var(--acm-dark);
     font-size: var(--body-font-size);
     text-transform: lowercase;
+    box-shadow: 0 0 0 rgba(23, 26, 28, 0.1);
+    transition: background-color 0.25s ease-in-out, color 0.25s ease-in-out,
+      -webkit-filter 0.25s ease-in-out, filter 0.25s ease-in-out;
   }
 
   .call-to-action:hover {
     transition: color 0.25s ease-in-out, background-color 0.25s ease-in-out;
-    color: var(--acm-blue);
-    background-color: var(--acm-light);
+    color: var(--acm-light);
+    background-color: var(--acm-dark);
+    -webkit-filter: drop-shadow(0 2px 10px rgba(23, 26, 28, 0.5));
+    filter: drop-shadow(0 2px 10px rgba(23, 26, 28, 0.5));
   }
 </style>

--- a/src/components/utils/acm-button.svelte
+++ b/src/components/utils/acm-button.svelte
@@ -23,14 +23,12 @@
     text-transform: lowercase;
     box-shadow: 0 0 0 rgba(23, 26, 28, 0.1);
     transition: background-color 0.25s ease-in-out, color 0.25s ease-in-out,
-      -webkit-filter 0.25s ease-in-out, filter 0.25s ease-in-out;
+      box-shadow 0.25s ease-in-out;
   }
 
   .call-to-action:hover {
-    transition: color 0.25s ease-in-out, background-color 0.25s ease-in-out;
     color: var(--acm-light);
     background-color: var(--acm-dark);
-    -webkit-filter: drop-shadow(0 2px 10px rgba(23, 26, 28, 0.5));
-    filter: drop-shadow(0 2px 10px rgba(23, 26, 28, 0.5));
+    box-shadow: 0 2px 10px rgba(23, 26, 28, 0.5);
   }
 </style>


### PR DESCRIPTION
Implemented @mikeploythai's button design. Now, a smoother transition happens when the user hovers over any button element on the site.

Default style:

![image](https://user-images.githubusercontent.com/31261035/116947610-107e7f80-ac32-11eb-850d-62bfb53ed718.png)

Style on hover:

![image](https://user-images.githubusercontent.com/31261035/116947648-2724d680-ac32-11eb-9334-b49f51f60769.png)
