### PR TITLE
Removed unneeded arrow buttons for event carousel

### DIFF
--- a/src/lib/components/events/event-carousel.svelte
+++ b/src/lib/components/events/event-carousel.svelte
@@ -2,6 +2,7 @@
 	import { onMount } from 'svelte';
 	import EventItem from './event-item.svelte';
 	import type { AcmEvent } from '$lib/ical/parse';
+	import { Time } from '$lib/constants/time';
 
 	export let events: AcmEvent[] = [];
 
@@ -13,18 +14,28 @@
 	let hasHorizontalScrollbar = false;
 	let leftButtonEnabled = false;
 	let rightButtonEnabled = false;
+	let scrollTimeId = undefined;
 
 	const scrollTheCarousel = (movementScalar: number, isSmooth: boolean = false) => {
 		carouselRef.scrollBy({
 			left: -movementScalar,
 			behavior: isSmooth ? 'smooth' : 'auto',
 		});
-		const canScrollLeft = carouselRef.scrollLeft > 0;
-		const canScrollRight =
-			carouselRef.scrollWidth - carouselRef.scrollLeft - carouselRef.clientWidth <
-			scrollIncrementDistance;
-		leftButtonEnabled = canScrollLeft;
-		rightButtonEnabled = canScrollRight;
+		debounceTheScroll(() => {
+			const canScrollLeft = carouselRef.scrollLeft > 0;
+			const canScrollRight =
+				carouselRef.scrollWidth - carouselRef.scrollLeft - carouselRef.clientWidth < 1;
+			leftButtonEnabled = canScrollLeft;
+			rightButtonEnabled = canScrollRight;
+		}, Time.Second * 0.75);
+	};
+
+	const debounceTheScroll = (callback: () => void, wait: number) => {
+		callback();
+		if (scrollTimeId !== undefined) {
+			clearTimeout(scrollTimeId);
+		}
+		scrollTimeId = setTimeout(callback, wait);
 	};
 	const scrollOnMouseMove = (event: MouseEvent) => isGrabbing && scrollTheCarousel(event.movementX);
 	const startGrabbing = () => (isGrabbing = true);
@@ -150,7 +161,7 @@
 		-webkit-user-select: none;
 		-ms-user-select: none;
 		user-select: none;
-		visibility: hidden;
+		opacity: 0;
 	}
 
 	.carousel-button:hover {
@@ -169,7 +180,7 @@
 	}
 
 	.enabled {
-		visibility: visible;
+		opacity: 1;
 	}
 	@media (max-width: 1219px) {
 		.event-carousel-container {

--- a/src/lib/components/events/event-carousel.svelte
+++ b/src/lib/components/events/event-carousel.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import EventItem from './event-item.svelte';
 	import type { AcmEvent } from '$lib/ical/parse';
+	import { onMount } from 'svelte';
 
 	export let events: AcmEvent[] = [];
 
@@ -15,6 +16,7 @@
 			left: -movementScalar,
 			behavior: isSmooth ? 'smooth' : 'auto',
 		});
+	var hasHorizontalScrollbar = false;
 	const scrollOnMouseMove = (event: MouseEvent) => isGrabbing && scrollTheCarousel(event.movementX);
 	const startGrabbing = () => (isGrabbing = true);
 	const endGrabbing = () => (isGrabbing = false);
@@ -24,13 +26,18 @@
 		event.preventDefault();
 		scrollTheCarousel(-event.deltaY);
 	};
+	onMount(() => {
+		hasHorizontalScrollbar = carouselRef.scrollWidth > carouselRef.clientWidth;
+	});
 </script>
 
 <section>
 	<div class="event-carousel-container">
-		<div bind:this={carouselButtonLeft} class="carousel-button left" on:click={scrollLeft}>
-			&lt;
-		</div>
+		{#if hasHorizontalScrollbar}
+			<div bind:this={carouselButtonLeft} class="carousel-button left" on:click={scrollLeft}>
+				&lt;
+			</div>
+		{/if}
 		<div
 			class="event-list"
 			bind:this={carouselRef}
@@ -46,9 +53,11 @@
 			{/each}
 			<div class="event-item-buffer" />
 		</div>
-		<div bind:this={carouselButtonRight} class="carousel-button right" on:click={scrollRight}>
-			&gt;
-		</div>
+		{#if hasHorizontalScrollbar}
+			<div bind:this={carouselButtonRight} class="carousel-button right" on:click={scrollRight}>
+				&gt;
+			</div>
+		{/if}
 	</div>
 </section>
 

--- a/src/lib/components/events/event-carousel.svelte
+++ b/src/lib/components/events/event-carousel.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
+	import { onMount } from 'svelte';
 	import EventItem from './event-item.svelte';
 	import type { AcmEvent } from '$lib/ical/parse';
-	import { onMount } from 'svelte';
 
 	export let events: AcmEvent[] = [];
 

--- a/src/lib/components/events/event-carousel.svelte
+++ b/src/lib/components/events/event-carousel.svelte
@@ -162,6 +162,7 @@
 		-ms-user-select: none;
 		user-select: none;
 		opacity: 0;
+		visibility: hidden;
 	}
 
 	.carousel-button:hover {
@@ -181,6 +182,7 @@
 
 	.enabled {
 		opacity: 1;
+		visibility: visible;
 	}
 	@media (max-width: 1219px) {
 		.event-carousel-container {

--- a/src/lib/components/events/event-carousel.svelte
+++ b/src/lib/components/events/event-carousel.svelte
@@ -16,7 +16,7 @@
 			left: -movementScalar,
 			behavior: isSmooth ? 'smooth' : 'auto',
 		});
-	var hasHorizontalScrollbar = false;
+	let hasHorizontalScrollbar = false;
 	const scrollOnMouseMove = (event: MouseEvent) => isGrabbing && scrollTheCarousel(event.movementX);
 	const startGrabbing = () => (isGrabbing = true);
 	const endGrabbing = () => (isGrabbing = false);
@@ -33,11 +33,13 @@
 
 <section>
 	<div class="event-carousel-container">
-		{#if hasHorizontalScrollbar}
-			<div bind:this={carouselButtonLeft} class="carousel-button left" on:click={scrollLeft}>
-				&lt;
-			</div>
-		{/if}
+		<div
+			bind:this={carouselButtonLeft}
+			class:enabled={hasHorizontalScrollbar}
+			class="carousel-button left"
+			on:click={scrollLeft}>
+			&lt;
+		</div>
 		<div
 			class="event-list"
 			bind:this={carouselRef}
@@ -53,11 +55,13 @@
 			{/each}
 			<div class="event-item-buffer" />
 		</div>
-		{#if hasHorizontalScrollbar}
-			<div bind:this={carouselButtonRight} class="carousel-button right" on:click={scrollRight}>
-				&gt;
-			</div>
-		{/if}
+		<div
+			bind:this={carouselButtonRight}
+			class:enabled={hasHorizontalScrollbar}
+			class="carousel-button right"
+			on:click={scrollRight}>
+			&gt;
+		</div>
 	</div>
 </section>
 
@@ -136,6 +140,7 @@
 		-webkit-user-select: none;
 		-ms-user-select: none;
 		user-select: none;
+		opacity: 0;
 	}
 
 	.carousel-button:hover {
@@ -151,6 +156,10 @@
 
 	.carousel-button.right {
 		right: 0;
+	}
+
+	.enabled {
+		opacity: 1;
 	}
 
 	@media (max-width: 1219px) {

--- a/src/lib/components/events/event-carousel.svelte
+++ b/src/lib/components/events/event-carousel.svelte
@@ -48,6 +48,7 @@
 	};
 	onMount(() => {
 		hasHorizontalScrollbar = carouselRef.scrollWidth > carouselRef.clientWidth;
+		rightButtonEnabled = hasHorizontalScrollbar;
 	});
 </script>
 
@@ -77,10 +78,9 @@
 		</div>
 		<div
 			bind:this={carouselButtonRight}
-			class:visibility={hasHorizontalScrollbar}
 			class="carousel-button right"
 			on:click={scrollRight}
-			class:enabled={!rightButtonEnabled === hasHorizontalScrollbar ? !rightButtonEnabled : false}>
+			class:enabled={rightButtonEnabled}>
 			&gt;
 		</div>
 	</div>

--- a/src/lib/components/events/event-carousel.svelte
+++ b/src/lib/components/events/event-carousel.svelte
@@ -10,13 +10,22 @@
 	let carouselButtonLeft: HTMLDivElement;
 	let carouselButtonRight: HTMLDivElement;
 	let isGrabbing = false;
+	let hasHorizontalScrollbar = false;
+	let leftButtonEnabled = false;
+	let rightButtonEnabled = false;
 
-	const scrollTheCarousel = (movementScalar: number, isSmooth: boolean = false) =>
+	const scrollTheCarousel = (movementScalar: number, isSmooth: boolean = false) => {
 		carouselRef.scrollBy({
 			left: -movementScalar,
 			behavior: isSmooth ? 'smooth' : 'auto',
 		});
-	let hasHorizontalScrollbar = false;
+		const canScrollLeft = carouselRef.scrollLeft > 0;
+		const canScrollRight =
+			carouselRef.scrollWidth - carouselRef.scrollLeft - carouselRef.clientWidth <
+			scrollIncrementDistance;
+		leftButtonEnabled = canScrollLeft;
+		rightButtonEnabled = canScrollRight;
+	};
 	const scrollOnMouseMove = (event: MouseEvent) => isGrabbing && scrollTheCarousel(event.movementX);
 	const startGrabbing = () => (isGrabbing = true);
 	const endGrabbing = () => (isGrabbing = false);
@@ -35,7 +44,7 @@
 	<div class="event-carousel-container">
 		<div
 			bind:this={carouselButtonLeft}
-			class:enabled={hasHorizontalScrollbar}
+			class:enabled={leftButtonEnabled}
 			class="carousel-button left"
 			on:click={scrollLeft}>
 			&lt;
@@ -57,9 +66,10 @@
 		</div>
 		<div
 			bind:this={carouselButtonRight}
-			class:enabled={hasHorizontalScrollbar}
+			class:visibility={hasHorizontalScrollbar}
 			class="carousel-button right"
-			on:click={scrollRight}>
+			on:click={scrollRight}
+			class:enabled={!rightButtonEnabled === hasHorizontalScrollbar ? !rightButtonEnabled : false}>
 			&gt;
 		</div>
 	</div>
@@ -140,7 +150,7 @@
 		-webkit-user-select: none;
 		-ms-user-select: none;
 		user-select: none;
-		opacity: 0;
+		visibility: hidden;
 	}
 
 	.carousel-button:hover {
@@ -159,9 +169,8 @@
 	}
 
 	.enabled {
-		opacity: 1;
+		visibility: visible;
 	}
-
 	@media (max-width: 1219px) {
 		.event-carousel-container {
 			width: 980px;

--- a/src/lib/components/events/event-carousel.svelte
+++ b/src/lib/components/events/event-carousel.svelte
@@ -24,7 +24,7 @@
 		debounceTheScroll(() => {
 			const canScrollLeft = carouselRef.scrollLeft > 0;
 			const canScrollRight =
-				carouselRef.scrollWidth - carouselRef.scrollLeft - carouselRef.clientWidth < 1;
+				carouselRef.scrollWidth - carouselRef.scrollLeft - carouselRef.clientWidth > 1;
 			leftButtonEnabled = canScrollLeft;
 			rightButtonEnabled = canScrollRight;
 		}, Time.Second * 0.75);


### PR DESCRIPTION
When the arrow buttons are unneeded they are hidden and return when the event carousel is scrollable.

Preceding abandoned PR: link-https://github.com/EthanThatOneKid/acmcsuf.com/pull/177. (It included 3 unnecessary files along with the 1 file I wanted to change)