### PR TITLE
Fix Spacing component parameters

### DIFF
--- a/src/lib/components/sections/spacing.svelte
+++ b/src/lib/components/sections/spacing.svelte
@@ -1,10 +1,13 @@
 <div />
 
 <style>
-	div {
+	:root {
 		--med: 100px;
 		--min: var(--med, 100px);
 		--max: var(--med, 100px);
+	}
+
+	div {
 		height: var(--min);
 	}
 


### PR DESCRIPTION
This commit fixes the Spacing component's CSS variables being
incorrectly set. They didn't work prior to this change, because of a
regression from PR #184.