### PR TITLE
Refactor flexbox to grid (Issues: #136)

### DIFF
--- a/src/lib/components/about/officer-profile-list.svelte
+++ b/src/lib/components/about/officer-profile-list.svelte
@@ -40,8 +40,7 @@
 					{name}
 					title={positions[TERMS[$termIndex]]}
 					{picture}
-					{placeholderPicture}
-				/>
+					{placeholderPicture} />
 			{/each}
 		</div>
 	</div>
@@ -67,9 +66,11 @@
 	}
 
 	.officer-profile-list {
-		display: flex;
-		flex-flow: row wrap;
+		display: grid;
+		grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
+		grid-gap: 64px;
+		justify-content: center;
+		align-items: center;
 		max-width: 1400px;
-		justify-content: space-evenly;
 	}
 </style>

--- a/src/lib/components/about/officer-profile-list.svelte
+++ b/src/lib/components/about/officer-profile-list.svelte
@@ -66,9 +66,11 @@
 	}
 
 	.officer-profile-list {
-		display: flex;
-		flex-flow: row wrap;
+		display: grid;
+		grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
+		grid-gap: 64px;
+		justify-content: center;
+		align-items: center;
 		max-width: 1400px;
-		justify-content: space-evenly;
 	}
 </style>

--- a/src/lib/components/about/officer-profile-list.svelte
+++ b/src/lib/components/about/officer-profile-list.svelte
@@ -67,10 +67,9 @@
 
 	.officer-profile-list {
 		display: grid;
-		grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
-		grid-gap: 64px;
+		grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
 		justify-content: center;
 		align-items: center;
-		max-width: 1400px;
+		max-width: calc(100vw - (64px * 2));
 	}
 </style>

--- a/src/lib/components/about/officer-profile.svelte
+++ b/src/lib/components/about/officer-profile.svelte
@@ -1,59 +1,53 @@
 <script lang="ts">
-  export let placeholderPicture: string = "placeholder.png";
-  export let name: string = "";
-  export let title: string = "";
-  export let picture: string = placeholderPicture;
+	export let placeholderPicture: string = 'placeholder.png';
+	export let name: string = '';
+	export let title: string = '';
+	export let picture: string = placeholderPicture;
 
-  let officerName = name;
-  let officerPicture = picture;
-  let titleHTML = title
-    .replace(/Create/, `<span class="brand-em brand-pink">Create</span>`)
-    .replace(/Algo/, `<span class="brand-em brand-purple">Algo</span>`)
-    .replace(/Dev/, `<span class="brand-em brand-bluer">Dev</span>`)
-    .replace(
-      /NodeBuds/,
-      `<span class="headers">node<span class="brand-em brand-red">Buds</span></span>`
-    );
+	let officerName = name;
+	let officerPicture = picture;
+	let titleHTML = title
+		.replace(/Create/, `<span class="brand-em brand-pink">Create</span>`)
+		.replace(/Algo/, `<span class="brand-em brand-purple">Algo</span>`)
+		.replace(/Dev/, `<span class="brand-em brand-bluer">Dev</span>`)
+		.replace(
+			/NodeBuds/,
+			`<span class="headers">node<span class="brand-em brand-red">Buds</span></span>`
+		);
 </script>
 
 <div class="officer-container">
-  <img
-    class="officer-image"
-    src="{`../assets/authors/${officerPicture}`}"
-    alt="{`Image of ${officerName}.`}"
-  />
-  <h3 class="headers">
-    {officerName}
-  </h3>
-  <p>
-    {@html titleHTML}
-  </p>
+	<img
+		class="officer-image"
+		src={`../assets/authors/${officerPicture}`}
+		alt={`Image of ${officerName}.`} />
+	<h3 class="headers">
+		{officerName}
+	</h3>
+	<p>
+		{@html titleHTML}
+	</p>
 </div>
 
 <style lang="scss">
-  @import "static/theme.scss";
+	@import 'static/theme.scss';
 
-  .officer-container {
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
-    align-items: center;
-    padding: 64px 64px 0;
-    text-align: center;
-  }
+	.officer-container {
+		text-align: center;
+	}
 
-  .officer-image {
-    width: 200px;
-    height: 200px;
-  }
+	.officer-image {
+		width: 200px;
+		height: 200px;
+	}
 
-  h3 {
-    color: var(--acm-dark);
-  }
+	h3 {
+		color: var(--acm-dark);
+	}
 
-  p {
-    font-weight: 500;
-    max-width: 250px;
-    color: var(--acm-dark);
-  }
+	p {
+		font-weight: 500;
+		max-width: 250px;
+		color: var(--acm-dark);
+	}
 </style>

--- a/src/lib/components/about/officer-profile.svelte
+++ b/src/lib/components/about/officer-profile.svelte
@@ -33,8 +33,12 @@
 	@import 'static/theme.scss';
 
 	.officer-container {
-		text-align: center;
+		display: flex;
+		flex-direction: column;
+		justify-content: center;
+		align-items: center;
 		padding: 64px 64px 0;
+		text-align: center;
 	}
 
 	.officer-image {

--- a/src/lib/components/about/officer-profile.svelte
+++ b/src/lib/components/about/officer-profile.svelte
@@ -34,6 +34,7 @@
 
 	.officer-container {
 		text-align: center;
+		padding: 64px 64px 0;
 	}
 
 	.officer-image {


### PR DESCRIPTION
I manage to refactor to grid but grid-template-columns: auto-fill doesn't work responsively as it should, I think this may be due to other component's style since auto-fill should auto adjust the grid columns according to the viewport width, any suggestions? I can use media query to determine number of columns easily, but I think auto-fill is a much cleaner solution, thanks!