### PR TITLE
Integrated issue channel label blocklist

### DIFF
--- a/.github/workflows/create_issue_channel.yaml
+++ b/.github/workflows/create_issue_channel.yaml
@@ -7,7 +7,7 @@ on:
 jobs:
   create_channel:
     runs-on: ubuntu-latest
-    if: ${{ !contains(String(github.event.issue.labels.*.name), 'automation' }}
+    if: ${{ !contains(github.event.issue.labels.*.name, 'automation') }}
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2

--- a/.github/workflows/create_issue_channel.yaml
+++ b/.github/workflows/create_issue_channel.yaml
@@ -10,7 +10,6 @@ jobs:
     if: ${{ !contains(String(github.event.issue.labels.*.name), 'automation' }}
     steps:
       - uses: actions/checkout@v2
-        if: ${{ steps.automation_check.result === "false" }}
       - uses: actions/setup-node@v2
         with:
           node-version: '16'

--- a/.github/workflows/create_issue_channel.yaml
+++ b/.github/workflows/create_issue_channel.yaml
@@ -7,6 +7,7 @@ on:
 jobs:
   create_channel:
     runs-on: ubuntu-latest
+    if: ${{ !(contains(github.event.issue.labels.*.name, 'automation')) }}
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2

--- a/.github/workflows/create_issue_channel.yaml
+++ b/.github/workflows/create_issue_channel.yaml
@@ -7,9 +7,10 @@ on:
 jobs:
   create_channel:
     runs-on: ubuntu-latest
-    if: ${{ !(contains(github.event.issue.labels.*.name, 'automation')) }}
+    if: ${{ !contains(String(github.event.issue.labels.*.name), 'automation' }}
     steps:
       - uses: actions/checkout@v2
+        if: ${{ steps.automation_check.result === "false" }}
       - uses: actions/setup-node@v2
         with:
           node-version: '16'

--- a/.github/workflows/create_issue_channel.yaml
+++ b/.github/workflows/create_issue_channel.yaml
@@ -7,7 +7,7 @@ on:
 jobs:
   create_channel:
     runs-on: ubuntu-latest
-    if: ${{ !contains(github.event.issue.labels.*.name, 'automation') }}
+    if: ${{ !contains(github.event.issue.labels.*.name, 'automation:officer') }}
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2


### PR DESCRIPTION
**Proposal**: Create an issue channel only if the issue is not an automation. As of right now, the label blocklist should only include any label including the term "automation" since that issue label fragment is reserved for automations, thus a dedicated text channel on Discord is not necessary.