### PR TITLE
Added Size Limit for `node_modules`

### DIFF
--- a/.github/workflows/check_website.yaml
+++ b/.github/workflows/check_website.yaml
@@ -45,5 +45,9 @@ jobs:
       - name: Check
         run: npm run check
 
+      # info: https://etok.codes/acmcsuf.com/blob/main/CONTRIBUTING.md#npm-bloat
+      - name: Test Dependency Size
+        run: npm run test:size
+
       - name: Build
         run: npm run build

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,6 +33,13 @@ npm run check # Use this command to find bugs in your website code.
 npm run build # Use this to make sure your code builds successfully.
 ```
 
+### NPM Bloat
+
+In this project, we set a threshold for how large the `/node_modules` folder can become after an `npm install`.
+In our [`package.json`](package.json), we set the size to 50 MB.
+
+To test the size of the dependencies in your local workspace, run `npm run test:size`.
+
 ## Architecture 🗿
 
 For architecture-related information, please refer to [`ARCHITECTURE.md`](ARCHITECTURE.md).

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "rrule": "^2.6.8"
       },
       "devDependencies": {
+        "@size-limit/file": "^7.0.4",
         "@sveltejs/adapter-static": "next",
         "@sveltejs/adapter-vercel": "next",
         "@sveltejs/kit": "next",
@@ -28,6 +29,7 @@
         "prettier": "^2.4.1",
         "prettier-plugin-svelte": "^2.4.0",
         "sass": "^1.42.1",
+        "size-limit": "^7.0.4",
         "svelte": "^3.42.6",
         "svelte-check": "^2.2.6",
         "svelte-preprocess": "^4.9.4",
@@ -305,6 +307,21 @@
       },
       "funding": {
         "url": "https://github.com/sindresorhus/is?sponsor=1"
+      }
+    },
+    "node_modules/@size-limit/file": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/@size-limit/file/-/file-7.0.4.tgz",
+      "integrity": "sha512-/UfiOp8bDIdmNs0c8IQgGKlByo1esoayZ6+Pr/LQCJPZWPyQWVeGTo+J/+aYa9+5+r6ezvmAF5aR7VVt+rvW2Q==",
+      "dev": true,
+      "dependencies": {
+        "semver": "7.3.5"
+      },
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "size-limit": "7.0.4"
       }
     },
     "node_modules/@sveltejs/adapter-static": {
@@ -734,6 +751,15 @@
         "node": "*"
       }
     },
+    "node_modules/bytes-iec": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/bytes-iec/-/bytes-iec-3.1.1.tgz",
+      "integrity": "sha512-fey6+4jDK7TFtFg/klGSvNKJctyU7n2aQdnM+CO0ruLPbqqMOM8Tio0Pc+deqUeVKX1tL5DQep1zQ7+37aTAsA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -788,6 +814,12 @@
       "optionalDependencies": {
         "fsevents": "~2.3.2"
       }
+    },
+    "node_modules/ci-job-number": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/ci-job-number/-/ci-job-number-1.2.2.tgz",
+      "integrity": "sha512-CLOGsVDrVamzv8sXJGaILUVI6dsuAkouJP/n6t+OxLPeeA4DDby7zn9SB6EUpa1H7oIKoE+rMmkW80zYsFfUjA==",
+      "dev": true
     },
     "node_modules/color-convert": {
       "version": "2.0.1",
@@ -1969,6 +2001,15 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/lilconfig": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.0.4.tgz",
+      "integrity": "sha512-bfTIN7lEsiooCocSISTWXkiWJkRqtL9wYtYy+8EK3Y41qh3mpwPU0ycTOgjdY9ErwXCc8QyrQp82bdL0Xkm9yA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/lodash.clonedeep": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
@@ -2131,6 +2172,21 @@
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
+    },
+    "node_modules/nanospinner": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/nanospinner/-/nanospinner-0.5.0.tgz",
+      "integrity": "sha512-VaEzZRHgdgvru4qr5Oe7SjalSGQsoCZrl42FEnAYHp8R+ghcok6u8Yo5U37kD+ABOjRh1IUOA64qqff+TznDfg==",
+      "dev": true,
+      "dependencies": {
+        "picocolors": "^1.0.0"
+      }
+    },
+    "node_modules/nanospinner/node_modules/picocolors": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
+      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
+      "dev": true
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",
@@ -2626,6 +2682,46 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/size-limit": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/size-limit/-/size-limit-7.0.4.tgz",
+      "integrity": "sha512-IkY30erk6psU6UCg/R0crNUIWIQsTTVv1/tMtY0ifOtq6Y2F2cUC3Z0zXNAmKcncnl9HJjUIQhw2WNYRlDiv0Q==",
+      "dev": true,
+      "dependencies": {
+        "bytes-iec": "^3.1.1",
+        "chokidar": "^3.5.2",
+        "ci-job-number": "^1.2.2",
+        "globby": "^11.0.4",
+        "lilconfig": "^2.0.3",
+        "mkdirp": "^1.0.4",
+        "nanospinner": "^0.5.0",
+        "picocolors": "^1.0.0"
+      },
+      "bin": {
+        "size-limit": "bin.js"
+      },
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/size-limit/node_modules/mkdirp": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "dev": true,
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/size-limit/node_modules/picocolors": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
+      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
+      "dev": true
     },
     "node_modules/slash": {
       "version": "3.0.0",
@@ -3357,6 +3453,15 @@
       "integrity": "sha512-VkE3KLBmJwcCaVARtQpfuKcKv8gcBmUubrfHGF84dXuuW6jgsRYxPtzcIhPyK9WAPpRt2/xY6zkD9MnRaJzSyw==",
       "dev": true
     },
+    "@size-limit/file": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/@size-limit/file/-/file-7.0.4.tgz",
+      "integrity": "sha512-/UfiOp8bDIdmNs0c8IQgGKlByo1esoayZ6+Pr/LQCJPZWPyQWVeGTo+J/+aYa9+5+r6ezvmAF5aR7VVt+rvW2Q==",
+      "dev": true,
+      "requires": {
+        "semver": "7.3.5"
+      }
+    },
     "@sveltejs/adapter-static": {
       "version": "1.0.0-next.21",
       "resolved": "https://registry.npmjs.org/@sveltejs/adapter-static/-/adapter-static-1.0.0-next.21.tgz",
@@ -3646,6 +3751,12 @@
       "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=",
       "dev": true
     },
+    "bytes-iec": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/bytes-iec/-/bytes-iec-3.1.1.tgz",
+      "integrity": "sha512-fey6+4jDK7TFtFg/klGSvNKJctyU7n2aQdnM+CO0ruLPbqqMOM8Tio0Pc+deqUeVKX1tL5DQep1zQ7+37aTAsA==",
+      "dev": true
+    },
     "callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -3683,6 +3794,12 @@
         "normalize-path": "~3.0.0",
         "readdirp": "~3.6.0"
       }
+    },
+    "ci-job-number": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/ci-job-number/-/ci-job-number-1.2.2.tgz",
+      "integrity": "sha512-CLOGsVDrVamzv8sXJGaILUVI6dsuAkouJP/n6t+OxLPeeA4DDby7zn9SB6EUpa1H7oIKoE+rMmkW80zYsFfUjA==",
+      "dev": true
     },
     "color-convert": {
       "version": "2.0.1",
@@ -4511,6 +4628,12 @@
         "type-check": "~0.4.0"
       }
     },
+    "lilconfig": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.0.4.tgz",
+      "integrity": "sha512-bfTIN7lEsiooCocSISTWXkiWJkRqtL9wYtYy+8EK3Y41qh3mpwPU0ycTOgjdY9ErwXCc8QyrQp82bdL0Xkm9yA==",
+      "dev": true
+    },
     "lodash.clonedeep": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
@@ -4637,6 +4760,23 @@
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.29.tgz",
       "integrity": "sha512-dW2pUSGZ8ZnCFIlBIA31SV8huOGCHb6OwzVCc7A69rb/a+SgPBwfmLvK5TKQ3INPbRkcI8a/Owo0XbiTNH19wg==",
       "dev": true
+    },
+    "nanospinner": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/nanospinner/-/nanospinner-0.5.0.tgz",
+      "integrity": "sha512-VaEzZRHgdgvru4qr5Oe7SjalSGQsoCZrl42FEnAYHp8R+ghcok6u8Yo5U37kD+ABOjRh1IUOA64qqff+TznDfg==",
+      "dev": true,
+      "requires": {
+        "picocolors": "^1.0.0"
+      },
+      "dependencies": {
+        "picocolors": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
+          "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
+          "dev": true
+        }
+      }
     },
     "natural-compare": {
       "version": "1.4.0",
@@ -4976,6 +5116,36 @@
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
       "dev": true
+    },
+    "size-limit": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/size-limit/-/size-limit-7.0.4.tgz",
+      "integrity": "sha512-IkY30erk6psU6UCg/R0crNUIWIQsTTVv1/tMtY0ifOtq6Y2F2cUC3Z0zXNAmKcncnl9HJjUIQhw2WNYRlDiv0Q==",
+      "dev": true,
+      "requires": {
+        "bytes-iec": "^3.1.1",
+        "chokidar": "^3.5.2",
+        "ci-job-number": "^1.2.2",
+        "globby": "^11.0.4",
+        "lilconfig": "^2.0.3",
+        "mkdirp": "^1.0.4",
+        "nanospinner": "^0.5.0",
+        "picocolors": "^1.0.0"
+      },
+      "dependencies": {
+        "mkdirp": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+          "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+          "dev": true
+        },
+        "picocolors": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
+          "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
+          "dev": true
+        }
+      }
     },
     "slash": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -18,13 +18,15 @@
     "check:watch": "svelte-check --tsconfig ./tsconfig.json --watch",
     "lint": "eslint --ignore-path .gitignore .",
     "format": "prettier --ignore-path .gitignore --write --plugin-search-dir=. .",
-    "tabs": "node scripts/seek-tabs.js"
+    "tabs": "node scripts/seek-tabs.js",
+    "test:size": "npm i && size-limit"
   },
   "dependencies": {
     "rfs": "^9.0.6",
     "rrule": "^2.6.8"
   },
   "devDependencies": {
+    "@size-limit/file": "^7.0.4",
     "@sveltejs/adapter-static": "next",
     "@sveltejs/adapter-vercel": "next",
     "@sveltejs/kit": "next",
@@ -41,10 +43,17 @@
     "prettier": "^2.4.1",
     "prettier-plugin-svelte": "^2.4.0",
     "sass": "^1.42.1",
+    "size-limit": "^7.0.4",
     "svelte": "^3.42.6",
     "svelte-check": "^2.2.6",
     "svelte-preprocess": "^4.9.4",
     "tslib": "^2.3.1",
     "typescript": "^4.4.3"
-  }
+  },
+  "size-limit": [
+    {
+      "path": "node_modules",
+      "limit": "50 MB"
+    }
+  ]
 }


### PR DESCRIPTION
I used this NPM package, [ai/size-limit](https://github.com/ai/size-limit), to help with calculating the size of our `node_modules` directory after a clean `npm i`. The size of `fix/247`'s `node_modules` was clocked at 39.91 MB gzipped (according to [run 4835296416](https://github.com/EthanThatOneKid/acmcsuf.com/runs/4835296416?check_suite_focus=true#step:8:23)), so I set the threshold to 50 MB as a starting point.

As we change our `package.json`, we should also contemplate and refer to the threshold in our `package.json`. If anything, we'd like to eventually _lower_ the threshold as time goes on.

Resolves #247.