### PR TITLE
Added createdAt to plaintext blogpost metadata

### DIFF
--- a/src/routes/blog/[id].txt.ts
+++ b/src/routes/blog/[id].txt.ts
@@ -17,8 +17,10 @@ function serializeNewsletter(newsletter: Newsletter) {
     `title: "${txtTitle}"`,
     `author: "${newsletter.author.displayname}` +
       (newsletter.author.url !== undefined ? ` (${newsletter.author.url})"` : '"'),
+    `html_url: "${newsletter.url}"`,
     `labels: [${newsletter.labels.map((l) => `"${l}"`).join(', ')}]`,
-    `date: "${new Date(newsletter.lastEdited).toISOString()}"`,
+    `created: "${new Date(newsletter.createdAt).toISOString()}"`,
+    `edited: "${new Date(newsletter.lastEdited).toISOString()}"`,
     `---`,
     '',
     txtTitle,

--- a/src/routes/blog/[id].txt.ts
+++ b/src/routes/blog/[id].txt.ts
@@ -9,25 +9,44 @@ interface ServerRequest extends IncomingRequest {
 }
 
 function serializeNewsletter(newsletter: Newsletter) {
-  const txtTitle = convertHtml2Txt(newsletter.title);
+  const lines: string[] = [];
 
-  return [
-    `---`,
-    `id: ${newsletter.id}`,
-    `title: "${txtTitle}"`,
-    `author: "${newsletter.author.displayname}` +
-      (newsletter.author.url !== undefined ? ` (${newsletter.author.url})"` : '"'),
-    `html_url: "${newsletter.url}"`,
-    `labels: [${newsletter.labels.map((l) => `"${l}"`).join(', ')}]`,
-    `created: "${new Date(newsletter.createdAt).toISOString()}"`,
-    `edited: "${new Date(newsletter.lastEdited).toISOString()}"`,
-    `---`,
-    '',
-    txtTitle,
-    '='.repeat(txtTitle.length),
-    '',
-    convertHtml2Txt(newsletter.html, { wordwrap: 100 }),
-  ].join('\n');
+  // Top of file is where blog metadata is displayed as YAML front matter
+  /*********** [[[ METADATA START ]]] ***********/
+  lines.push('---');
+
+  const txtTitle = convertHtml2Txt(newsletter.title);
+  lines.push(`title: ${txtTitle}`);
+
+  lines.push(`id: ${newsletter.id}`);
+  lines.push(`html_url: "${newsletter.url}"`);
+  lines.push(`discussion_url: $"{newsletter.discussionUrl}"`);
+
+  const author =
+    newsletter.author.displayname +
+    (newsletter.author.url !== undefined ? ` (${newsletter.author.url})` : '');
+  lines.push(`author: "${author}"`);
+
+  const labels = newsletter.labels.map((l) => `"${l}"`).join(', ');
+  lines.push(`labels: [${labels}]`);
+
+  lines.push(`created: "${new Date(newsletter.createdAt).toISOString()}"`);
+
+  if (newsletter.lastEdited) {
+    lines.push(`edited: "${new Date(newsletter.lastEdited).toISOString()}"`);
+  }
+
+  lines.push('---');
+  /*********** [[[ METADATA END ]]] ***********/
+
+  // Add title with padding
+  lines.push('');
+  lines.push(txtTitle);
+  lines.push('='.repeat(txtTitle.length));
+  lines.push('');
+
+  // Add blog content
+  return lines.concat(convertHtml2Txt(newsletter.html, { wordwrap: 100 })).join('\n');
 }
 
 // Query the newsletter endpoint itself instead of the lib in order to

--- a/src/routes/blog/_query.ts
+++ b/src/routes/blog/_query.ts
@@ -68,7 +68,7 @@ function formatNewsletters(output: any): Newsletter[] {
       title,
       author,
       createdAt,
-      lastEdited,
+      lastEditedAt: lastEdited,
       number: id,
       bodyHTML: html,
       url: discussionUrl,

--- a/src/routes/blog/_query.ts
+++ b/src/routes/blog/_query.ts
@@ -7,6 +7,7 @@ export interface Newsletter {
   discussionUrl: string;
   title: string;
   html: string;
+  createdAt: number | null;
   lastEdited: number | null;
   labels: string[];
   author: {
@@ -16,7 +17,10 @@ export interface Newsletter {
   };
 }
 
-// @see https://docs.github.com/en/graphql/overview/explorer
+/**
+ * GraphQL query to get all the blog posts from the newsletters category.
+ * @see https://docs.github.com/en/graphql/overview/explorer
+ */
 export const newslettersQuery = `{
   repository(owner: "ethanthatonekid", name: "acmcsuf.com") {
     discussions(first: 100, categoryId: "${import.meta.env.VITE_GH_DISCUSSION_CATEGORY_ID}") {
@@ -54,11 +58,22 @@ function getOfficerByGhUsername(ghUsername: string): Officer | null {
 function formatNewsletters(output: any): Newsletter[] {
   const discussions = output.data.repository.discussions.nodes;
 
+  /**
+   * No types exist for the discussion object, as the structure is generated
+   * based on the GraphQL {@link newslettersQuery}.
+   */
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   return discussions.map((discussion: any): Newsletter => {
-    const { title, author, number: id, bodyHTML: html, url: discussionUrl } = discussion;
+    const {
+      title,
+      author,
+      createdAt,
+      lastEdited,
+      number: id,
+      bodyHTML: html,
+      url: discussionUrl,
+    } = discussion;
     const url = '/blog/' + id;
-    const lastEdited = discussion.lastEditedAt ?? discussion.createdAt;
     const labels = discussion.labels.nodes.map(({ name }) => name);
     const officer = getOfficerByGhUsername(author.login);
     const authorUrl: string = officer?.url ?? author.url;
@@ -71,6 +86,7 @@ function formatNewsletters(output: any): Newsletter[] {
       discussionUrl,
       title,
       html,
+      createdAt,
       lastEdited,
       labels,
       author: { url: authorUrl, displayname, picture },


### PR DESCRIPTION
I just added the HTML URL in the metadata in case the user wants to go back to pretty HTML. Also swapped out ambiguous "date" metadata with "created" that represents the timestamp at which the post was initially created.

Resolves #275.