### PR TITLE
Removed `async` from non-async function in close-issue-channel.js

### DIFF
--- a/scripts/close-issue-channel.js
+++ b/scripts/close-issue-channel.js
@@ -84,7 +84,7 @@ async function closeIssueChannel(client, issueNumber, dev = false) {
   return success;
 }
 
-async function fetchAllMessages(channel, limit = 2e3) {
+function fetchAllMessages(channel, limit = 2e3) {
   const result = [];
   const softLimit = 100;
   let lastId;


### PR DESCRIPTION
After some snooping, I noticed an unneeded `async` on <https://github.com/EthanThatOneKid/acmcsuf.com/blob/a7e23991171b347b525697e41e4c90252ce71925/scripts/close-issue-channel.js#L104>

Resolves #282.

**Note**: Adding unit testing to this project in [v3.0](https://github.com/EthanThatOneKid/acmcsuf.com/milestone/3) could prevent a spontaneous issue like this from happening in the future.