### PR TITLE
Only send messages in open issue channels

### DIFF
--- a/.github/workflows/create_message.yaml
+++ b/.github/workflows/create_message.yaml
@@ -8,7 +8,7 @@ on:
 jobs:
   issue_commented:
     name: Issue comment
-    if: ${{ !(github.event.issue.pull_request) }}
+    if: ${{ !(github.event.issue.pull_request) && (github.event.issue.state == "open") }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Updated this workflow to only send messages in open issue channels. 

**Proposal**: Skip sending issue comments to Discord from closed issues.

Resolves #294.