### PR TITLE
Events: Join from new tab

### DIFF
--- a/src/lib/components/events/event-item.svelte
+++ b/src/lib/components/events/event-item.svelte
@@ -45,7 +45,12 @@
           {#if isRecurring}(recurring){/if}
         </time>
       </p>
-      <a class="event-join size-s" href={info.meetingLink} role="button">Join</a>
+      <a
+        class="event-join size-s"
+        href={info.meetingLink}
+        role="button"
+        target="_blank"
+        rel="noopener noreferrer">Join</a>
     </summary>
     <hr />
     <p class="event-description">{info.description}</p>


### PR DESCRIPTION
Upon clicking a "Join" button, the join link is opened in a new tab using `target="_blank"`.

Resolves #292. 