### PR TITLE
Events: Force long words to break in event item description

### DIFF
--- a/src/lib/components/events/event-item.svelte
+++ b/src/lib/components/events/event-item.svelte
@@ -272,6 +272,7 @@
   .event-description {
     margin-top: 24px;
     margin-bottom: 24px;
+    word-break: break-all;
   }
 
   .event-description:empty::after {


### PR DESCRIPTION
All I had to do was add `word-break: break-all;`. Inspired by <https://css-tricks.com/almanac/properties/w/word-break/>.

### Before/After Screenshots

**Before** (from #330): 
<img width="589" alt="image" src="https://user-images.githubusercontent.com/31261035/158008088-a7d69230-32c6-405f-b5a6-b64972f2cdda.png">

**After**:
![image](https://user-images.githubusercontent.com/31261035/158008163-932e7265-77bc-4cc7-9070-c29ae0abda94.png)

Resolves #330.