### PR TITLE
Events: Force long words to break in event item description pt. 2

### DIFF
--- a/src/lib/components/events/event-item.svelte
+++ b/src/lib/components/events/event-item.svelte
@@ -272,7 +272,6 @@
   .event-description {
     margin-top: 24px;
     margin-bottom: 24px;
-    word-break: break-all;
   }
 
   .event-description:empty::after {

--- a/src/lib/components/events/event-item.svelte
+++ b/src/lib/components/events/event-item.svelte
@@ -272,6 +272,7 @@
   .event-description {
     margin-top: 24px;
     margin-bottom: 24px;
+    word-break: break-all;
   }
 
   .event-description:empty::after {

--- a/src/lib/components/events/event-item.svelte
+++ b/src/lib/components/events/event-item.svelte
@@ -272,7 +272,7 @@
   .event-description {
     margin-top: 24px;
     margin-bottom: 24px;
-    word-break: break-all;
+    overflow-wrap: break-word;
   }
 
   .event-description:empty::after {


### PR DESCRIPTION
All I had to do was add `overflow-wrap: break-word;`. Inspired by <https://css-tricks.com/almanac/properties/o/overflow-wrap/>.

Resolves #330.