### PR TITLE
Change color of officer title prefixes only

### DIFF
--- a/src/lib/components/about/officer-profile.svelte
+++ b/src/lib/components/about/officer-profile.svelte
@@ -11,9 +11,9 @@
   const officerPicture = info.picture ?? placeholderPicture;
 
   $: titleHTML = info.positions[VISIBLE_TERMS[$termIndex]].title
-    .replace(/Create/, `<span class="brand-em brand-pink">Create</span>`)
-    .replace(/Algo/, `<span class="brand-em brand-purple">Algo</span>`)
-    .replace(/Dev/, `<span class="brand-em brand-bluer">Dev</span>`)
+    .replace(/Create\s/, `<span class="brand-em brand-pink">Create </span>`)
+    .replace(/Algo\s/, `<span class="brand-em brand-purple">Algo </span>`)
+    .replace(/Dev\s/, `<span class="brand-em brand-bluer">Dev </span>`)
     .replace(
       /NodeBuds/,
       `<span class="headers">node<span class="brand-em brand-red">Buds</span></span>`


### PR DESCRIPTION
Co-Authored-By: Mohamed Habarneh <92408806+MohamedHabarneh@users.noreply.github.com>
Fixed about page coloring of paths in front of officer titles

Fixes: https://github.com/EthanThatOneKid/acmcsuf.com/issues/384