### PR TITLE
Create `/algo` subpage

### DIFF
--- a/src/lib/components/sections/common-hero.svelte
+++ b/src/lib/components/sections/common-hero.svelte
@@ -23,5 +23,6 @@
 
   section div :global(p) {
     margin-top: 16px;
+    font-size: var(--size-sm);
   }
 </style>

--- a/src/lib/components/sections/footer.svelte
+++ b/src/lib/components/sections/footer.svelte
@@ -48,8 +48,8 @@
         >Get in Touch
       </a>
 
-      <a href="/algo" class="brand-med size-sm" target="_blank" rel="noopener noreferrer"
-        >acm<span class="brand-purple brand-em">Algo</span>
+      <a href="/algo" class="brand-med size-sm">
+        acm<span class="brand-purple brand-em">Algo</span>
       </a>
     </div>
 

--- a/src/lib/components/sections/footer.svelte
+++ b/src/lib/components/sections/footer.svelte
@@ -47,6 +47,10 @@
         rel="noopener noreferrer"
         >Get in Touch
       </a>
+
+      <a href="/algo" class="brand-med size-sm" target="_blank" rel="noopener noreferrer"
+        >acm<span class="brand-purple brand-em">Algo</span>
+      </a>
     </div>
 
     <div class="more">

--- a/src/routes/algo/[id].json.ts
+++ b/src/routes/algo/[id].json.ts
@@ -1,0 +1,32 @@
+import type { RequestEvent, RequestHandlerOutput } from '@sveltejs/kit/types/internal';
+import type { AlgoResource } from './_query';
+
+async function getCache(id: number, origin: string) {
+  const target = origin + `/algo.json`;
+
+  try {
+    const response = await fetch(target);
+    const data = await response.json();
+    const newsletter = (data as AlgoResource[]).find((item) => {
+      return item.id === id;
+    });
+    return newsletter;
+  } catch (err) {
+    console.error(err);
+    return undefined;
+  }
+}
+
+export async function get(event: RequestEvent<{ id: string }>): Promise<RequestHandlerOutput> {
+  const id = Number(event.params.id);
+  const payload = await getCache(id, event.url.origin);
+
+  if (typeof payload === 'undefined') {
+    return new Response(null, { status: 404, headers: { 'Content-Type': 'application/json' } });
+  }
+
+  return new Response(JSON.stringify(payload), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}

--- a/src/routes/algo/[id].svelte
+++ b/src/routes/algo/[id].svelte
@@ -1,0 +1,101 @@
+<script lang="ts" context="module">
+  import type { LoadInput, LoadOutput } from '@sveltejs/kit/types/internal';
+
+  export async function load({ fetch, params }: LoadInput): Promise<LoadOutput> {
+    const response = await fetch(`/algo/${params.id}.json`);
+    const newsletter = await response.json();
+
+    if (typeof newsletter?.id !== 'number') {
+      return { status: 404 };
+    }
+
+    return { props: { post: newsletter } };
+  }
+</script>
+
+<script lang="ts">
+  import type { AlgoResource } from './_query';
+  import Spacing from '$lib/components/sections/spacing.svelte';
+
+  export let post: AlgoResource;
+</script>
+
+<svelte:head>
+  <title>{post.title}</title>
+</svelte:head>
+
+<Spacing --min="175px" --med="200px" --max="200px" />
+
+<section>
+  <h1 class="headers size-lg">{post.title}</h1>
+
+  <Spacing --min="16px" --med="16px" --max="16px" />
+
+  <p>
+    by
+    <a
+      href={'https://github.com/' + post.author.displayname}
+      target="_blank"
+      rel="noopener noreferrer"
+    >
+      @{post.author.displayname}
+    </a>
+  </p>
+
+  <Spacing --min="75px" --med="100px" --max="150px" />
+
+  <div class="container">
+    <div class="markdown-body">
+      {@html post.html}
+    </div>
+
+    {#if post.labels.length > 0}
+      <small class="ita">Tags: {post.labels.join(', ')}</small>
+      <br />
+    {/if}
+
+    <small class="ita">Read as TXT: <a href={`${post.url}.txt`}>{post.url}.txt</a></small>
+  </div>
+
+  <Spacing />
+</section>
+
+<style lang="scss">
+  section {
+    display: flex;
+    flex-direction: column;
+    text-align: center;
+    justify-content: center;
+    align-items: center;
+    padding: 0 24px;
+
+    a {
+      text-decoration: none;
+      font-weight: 500;
+      transition: 0.25s ease-in-out;
+
+      &:hover {
+        color: var(--acm-blue);
+      }
+    }
+  }
+
+  .container {
+    text-align: left;
+    padding: 4em 4em 3em;
+    margin: 0;
+    background-color: var(--acm-light);
+    border-radius: 3em;
+    filter: drop-shadow(0 8px 40px rgba(16, 19, 21, 0.1));
+    -webkit-filter: drop-shadow(0 8px 40px rgba(16, 19, 21, 0.1));
+    width: min(1000px, 70vw);
+
+    .markdown-body {
+      text-align: left;
+
+      :global(p) {
+        margin-bottom: 16px;
+      }
+    }
+  }
+</style>

--- a/src/routes/algo/_index.test.ts
+++ b/src/routes/algo/_index.test.ts
@@ -11,5 +11,5 @@ test('can render', () => {
 
 test('can find the correct page title', () => {
   const { getByText } = render(Blog);
-  expect(getByText('The official acmCSUF blog.')).toBeDefined();
+  expect(getByText('What is acmAlgo?')).toBeDefined();
 });

--- a/src/routes/algo/_index.test.ts
+++ b/src/routes/algo/_index.test.ts
@@ -1,15 +1,15 @@
 import { beforeEach, test, expect } from 'vitest';
 import { cleanup, render } from '@testing-library/svelte';
 
-import Blog from './index.svelte';
+import Algo from './index.svelte';
 
 beforeEach(cleanup);
 
 test('can render', () => {
-  render(Blog);
+  render(Algo);
 });
 
 test('can find the correct page title', () => {
-  const { getByText } = render(Blog);
+  const { getByText } = render(Algo);
   expect(getByText('What is acmAlgo?')).toBeDefined();
 });

--- a/src/routes/algo/_index.test.ts
+++ b/src/routes/algo/_index.test.ts
@@ -11,5 +11,7 @@ test('can render', () => {
 
 test('can find the correct page title', () => {
   const { getByText } = render(Algo);
-  expect(getByText('What is acmAlgo?')).toBeDefined();
+  expect(
+    getByText('This path is dedicated to building the programming proficiency of students.')
+  ).toBeDefined();
 });

--- a/src/routes/algo/_index.test.ts
+++ b/src/routes/algo/_index.test.ts
@@ -1,0 +1,15 @@
+import { beforeEach, test, expect } from 'vitest';
+import { cleanup, render } from '@testing-library/svelte';
+
+import Blog from './index.svelte';
+
+beforeEach(cleanup);
+
+test('can render', () => {
+  render(Blog);
+});
+
+test('can find the correct page title', () => {
+  const { getByText } = render(Blog);
+  expect(getByText('The official acmCSUF blog.')).toBeDefined();
+});

--- a/src/routes/algo/_query.ts
+++ b/src/routes/algo/_query.ts
@@ -1,0 +1,109 @@
+import type { Officer } from '$lib/constants';
+import { OFFICERS } from '$lib/constants';
+
+export interface AlgoResource {
+  id: number;
+  url: string;
+  discussionUrl: string;
+  title: string;
+  html: string;
+  createdAt: number | null;
+  lastEdited: number | null;
+  labels: string[];
+  author: {
+    displayname: string;
+    url: string;
+    picture: string;
+  };
+}
+
+/**
+ * GraphQL query to get all the algo posts from the newsletters category.
+ * @see https://docs.github.com/en/graphql/overview/explorer
+ */
+export const newslettersQuery = `{
+  repository(owner: "ethanthatonekid", name: "acmcsuf.com") {
+    discussions(first: 100, categoryId: "${import.meta.env.VITE_GH_ALGO_DISCUSSION_CATEGORY_ID}") {
+      nodes {
+        title
+        url
+        number
+        bodyHTML
+        createdAt
+        lastEditedAt
+        
+        author {
+          login
+          url
+          avatarUrl
+        }
+        
+        labels(first: 100) {
+          nodes {
+            name
+          }
+        }
+      }
+    }
+  }
+}`;
+
+function getOfficerByGhUsername(ghUsername: string): Officer | null {
+  // get author by GitHub username
+  const officer = OFFICERS.find((o) => o.displayName !== undefined && o.displayName === ghUsername);
+  return officer ?? null;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function formatNewsletters(output: any): AlgoResource[] {
+  console.log({ output });
+  const discussions = output.data.repository.discussions.nodes;
+
+  /**
+   * No types exist for the discussion object, as the structure is generated
+   * based on the GraphQL {@link newslettersQuery}.
+   */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return discussions.map((discussion: any): AlgoResource => {
+    const {
+      title,
+      author,
+      createdAt,
+      lastEditedAt: lastEdited,
+      number: id,
+      bodyHTML: html,
+      url: discussionUrl,
+    } = discussion;
+    const url = '/algo/' + id;
+    const labels = discussion.labels.nodes.map(({ name }) => name);
+    const officer = getOfficerByGhUsername(author.login);
+    const authorUrl: string = author.url;
+    const displayname: string = officer?.fullName ?? author.login;
+    const picture: string = officer?.picture ?? author.avatarUrl;
+
+    return {
+      id,
+      url,
+      discussionUrl,
+      title,
+      html,
+      createdAt,
+      lastEdited,
+      labels,
+      author: { url: authorUrl, displayname, picture },
+    };
+  });
+}
+
+export async function fetchNewsletters(): Promise<AlgoResource[]> {
+  const ghAccessToken = import.meta.env.VITE_GH_ACCESS_TOKEN;
+
+  const response = await fetch('https://api.github.com/graphql', {
+    method: 'POST',
+    headers: { Authorization: `token ${ghAccessToken}`, 'Content-Type': 'application/json' },
+    body: JSON.stringify({ query: newslettersQuery }),
+  });
+
+  const newsletters = formatNewsletters(await response.json());
+  return newsletters;
+}

--- a/src/routes/algo/_query.ts
+++ b/src/routes/algo/_query.ts
@@ -23,7 +23,7 @@ export interface AlgoResource {
  */
 export const newslettersQuery = `{
   repository(owner: "ethanthatonekid", name: "acmcsuf.com") {
-    discussions(first: 100, categoryId: "${import.meta.env.VITE_GH_ALGO_DISCUSSION_CATEGORY_ID}") {
+    discussions(first: 100, categoryId: "${import.meta.env.VITE_GH_ALGO_CATEGORY_ID}") {
       nodes {
         title
         url

--- a/src/routes/algo/index.json.ts
+++ b/src/routes/algo/index.json.ts
@@ -1,0 +1,9 @@
+import type { RequestHandlerOutput } from '@sveltejs/kit/types/internal';
+import { fetchNewsletters } from './_query';
+
+export async function get(): Promise<RequestHandlerOutput> {
+  return new Response(JSON.stringify(await fetchNewsletters()), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}

--- a/src/routes/algo/index.svelte
+++ b/src/routes/algo/index.svelte
@@ -1,0 +1,136 @@
+<script lang="ts" context="module">
+  import type { LoadInput, LoadOutput } from '@sveltejs/kit/types/internal';
+
+  export async function load({ fetch }: LoadInput): Promise<LoadOutput> {
+    const response = await fetch(`/algo.json`);
+    return { props: { posts: await response.json() } };
+  }
+</script>
+
+<script lang="ts">
+  import type { AlgoResource } from './_query';
+  import Spacing from '$lib/components/sections/spacing.svelte';
+  import CommonHero from '$lib/components/sections/common-hero.svelte';
+
+  export let posts: AlgoResource[] = [];
+</script>
+
+<svelte:head>
+  <title>acmCSUF / README</title>
+</svelte:head>
+
+<Spacing --min="175px" --med="200px" --max="200px" />
+
+<section>
+  <!-- <img src="assets/readme-logomark.svg" alt="README by acmCSUF" /> -->
+
+  <CommonHero>
+    <h2 slot="headline" class="size-lg">
+      What is acm<span class="brand-purple brand-em">Algo</span>?
+    </h2>
+    <p slot="text" class="size-xs">
+      This path is dedicated to building the programming proficiency of students. acm<span
+        class="brand-purple brand-em">Algo</span
+      > focuses on mastering data structures and algorithms, enhancing problem solving abilities, and
+      exploration of competitive programming.
+    </p>
+  </CommonHero>
+
+  <Spacing --min="100px" --med="175px" --max="200px" />
+
+  <ul>
+    {#each posts as post (post.id)}
+      <li>
+        <a href={`/algo/${post.id}`} sveltekit:prefetch>
+          <h2 class="headers">{post.title}</h2>
+          <div class="markdown-body">
+            {@html post.html}
+          </div>
+          <small class="ita">{post.labels.join(', ')}</small>
+        </a>
+      </li>
+    {/each}
+  </ul>
+</section>
+
+<Spacing --min="40px" --med="95px" --max="120px" />
+
+<style lang="scss">
+  .subtitle {
+    a {
+      display: inline-block;
+      padding-left: 2.5vw;
+      vertical-align: baseline;
+
+      img {
+        width: 18px;
+        height: 18px;
+      }
+    }
+  }
+
+  section {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    margin: 0 24px;
+
+    * {
+      transition: 0.25s ease-in-out;
+    }
+
+    img {
+      max-width: 600px;
+      width: 100%;
+      height: auto;
+      margin-left: -2.2vw;
+      margin-bottom: 8px;
+    }
+
+    ul {
+      list-style: none;
+      padding: 3em 4em 2.5em;
+      margin: 0;
+      background-color: var(--acm-light);
+      border-radius: 3em;
+      filter: drop-shadow(0 8px 40px rgba(16, 19, 21, 0.1));
+      -webkit-filter: drop-shadow(0 8px 40px rgba(16, 19, 21, 0.1));
+      width: min(1000px, 70vw);
+
+      li {
+        cursor: pointer;
+        background-color: rgba(var(--acm-algo-rgb), 0.25);
+        border-radius: 1em;
+        padding: 2em;
+        margin: 2em 0;
+
+        a {
+          text-decoration: none;
+
+          .markdown-body {
+            max-height: 100px;
+            overflow: hidden;
+            margin: 16px 0;
+          }
+        }
+
+        &:hover {
+          background-color: rgba(var(--acm-algo-rgb), 0.5);
+        }
+      }
+    }
+  }
+
+  @media (max-width: 900px) {
+    section {
+      ul {
+        padding: 1em 2.5em;
+
+        li {
+          border-radius: 1.5em;
+        }
+      }
+    }
+  }
+</style>


### PR DESCRIPTION
This page is meant to be the hub for all acmAlgo information. This will provide convenience for the acmAlgo officers who weekly teach about algorithms and data structures.

### Changes

- [x] Added `/algo` page with matching infrastructure to the [`/blog`](https://github.com/EthanThatOneKid/acmcsuf.com/blob/main/src/routes/blog)
- [ ] Use [match routing](https://kit.svelte.dev/docs/routing#advanced-routing-matching)
- [ ] Add hover effect to "Algo" title on `/paths` that links to `/algo` with  instructions for going to the acmAlgo page: "Click on one of the paths to find out more" (suggested by @Angel-Armendariz via Discord)

Resolves #420.