### PR TITLE
Added replaceHtmlWithExternalLinks function to utils.ts

### DIFF
--- a/src/lib/ical/utils.test.ts
+++ b/src/lib/ical/utils.test.ts
@@ -2,7 +2,14 @@ import { assert, test, expect } from 'vitest';
 import { Temporal } from '@js-temporal/polyfill';
 import { readFileSync } from 'fs';
 import { parse } from './parse';
-import { makeEventSlug, parseDescription, makeEventLink, wrapText, walkICAL } from './utils';
+import {
+  makeEventSlug,
+  parseDescription,
+  makeEventLink,
+  wrapText,
+  walkICAL,
+  replaceHtmlWithExternalLinks,
+} from './utils';
 
 test('parses sample ICAL payload', () => {
   const rawICAL = readFileSync('./src/routes/events/_testdata/events.ics', 'utf-8');
@@ -68,4 +75,19 @@ test('wraps long text into lines broken at column 100 3 times', () => {
   const lines = wrapText('*'.repeat(301), 100);
   assert(lines.length === 4, 'wraps text into 3 times, making 4 lines');
   assert(lines.at(-1).length === 1, 'where the last line is a single asterisk');
+});
+
+test('replaces HTML with external links', () => {
+  const actual = replaceHtmlWithExternalLinks(`<a href="https://example.com/">
+  <a>
+  <a title="example" href="https://example.com/">
+  <a title="example" target="_self" href="https://example.com/">
+  <a title="example" target="_blank" href="https://example.com/">
+  example`);
+  expect(actual).toBe(`<a href="https://example.com/" target="_blank">
+  <a>
+  <a title="example" href="https://example.com/" target="_blank">
+  <a title="example" target="_self" href="https://example.com/" target="_blank">
+  <a title="example" target="_blank" href="https://example.com/">
+  example`);
 });

--- a/src/lib/ical/utils.test.ts
+++ b/src/lib/ical/utils.test.ts
@@ -87,7 +87,21 @@ test('replaces HTML with external links', () => {
   expect(actual).toBe(`<a href="https://example.com/" target="_blank">
   <a>
   <a title="example" href="https://example.com/" target="_blank">
-  <a title="example" target="_self" href="https://example.com/" target="_blank">
+  <a title="example" href="https://example.com/" target="_blank">
   <a title="example" target="_blank" href="https://example.com/">
+  example`);
+});
+
+test('additional replaces HTML with external links tests', () => {
+  const actual =
+    replaceHtmlWithExternalLinks(`<a title="example" target="_self"  href="https://example.com/">
+  <a title="example" target="_self"href="https://example.com/">
+  <a target="_self" title="example" href="https://example.com/">
+  <a title="example" target="_self" target="poggers" target="not poggers"  href="https://example.com/">
+  example`);
+  expect(actual).toBe(`<a title="example" href="https://example.com/" target="_blank">
+  <a title="example" href="https://example.com/" target="_blank">
+  <a title="example" href="https://example.com/" target="_blank">
+  <a title="example" href="https://example.com/" target="_blank">
   example`);
 });

--- a/src/lib/ical/utils.test.ts
+++ b/src/lib/ical/utils.test.ts
@@ -83,12 +83,14 @@ test('replaces HTML with external links', () => {
   <a title="example" href="https://example.com/">
   <a title="example" target="_self" href="https://example.com/">
   <a title="example" target="_blank" href="https://example.com/">
+  <article href="https://example.com/">example</article>
   example`);
   expect(actual).toBe(`<a href="https://example.com/" target="_blank">
   <a>
   <a title="example" href="https://example.com/" target="_blank">
   <a title="example" href="https://example.com/" target="_blank">
   <a title="example" target="_blank" href="https://example.com/">
+  <article href="https://example.com/">example</article>
   example`);
 });
 

--- a/src/lib/ical/utils.test.ts
+++ b/src/lib/ical/utils.test.ts
@@ -100,8 +100,10 @@ test('additional replaces HTML with external links tests', () => {
   <a title="example" target="_self"href="https://example.com/">
   <a target="_self" title="example" href="https://example.com/">
   <a title="example" target="_self" target="poggers" target="not poggers"  href="https://example.com/">
+  <a title="example" target="" href="https://example.com/">
   example`);
   expect(actual).toBe(`<a title="example" href="https://example.com/" target="_blank">
+  <a title="example" href="https://example.com/" target="_blank">
   <a title="example" href="https://example.com/" target="_blank">
   <a title="example" href="https://example.com/" target="_blank">
   <a title="example" href="https://example.com/" target="_blank">

--- a/src/lib/ical/utils.ts
+++ b/src/lib/ical/utils.ts
@@ -153,7 +153,7 @@ export function produceSummary(title: string, description: string, selfLink: str
 export function replaceHtmlWithExternalLinks(html: string): string {
   return html.replace(/<a.*href=".*".*>/gm, (match: string): string => {
     if (match.includes('target="_blank"')) return match;
-    match = match.replace(/target="_.*"/g, '');
+    match = match.replace(/target=".*?"\W*/g, '');
     return match.slice(0, match.length - 1) + ' target="_blank">';
   });
 }

--- a/src/lib/ical/utils.ts
+++ b/src/lib/ical/utils.ts
@@ -150,7 +150,7 @@ export function produceSummary(title: string, description: string, selfLink: str
     : title + ' — ' + selfLink;
 }
 
-function assertHtmlHasAllExternalLinks(html: string): string {
+function replaceHtmlWithExternalLinks(html: string): string {
   return html.replace(/<a.*href=".*">/gm, (match: string): string => {
     if (match.includes('target="_blank"')) return match;
     return match.replace(/target=“_.*”/g, '').slice(0, match.length - 1) + ' target="_blank">';
@@ -189,7 +189,7 @@ export function parseDescription(
     description = (description.substring(0, start) + description.substring(end)).trim();
   }
 
-  description = assertHtmlHasAllExternalLinks(description);
+  description = replaceHtmlWithExternalLinks(description);
 
   return { description, variables };
 }

--- a/src/lib/ical/utils.ts
+++ b/src/lib/ical/utils.ts
@@ -150,10 +150,11 @@ export function produceSummary(title: string, description: string, selfLink: str
     : title + ' — ' + selfLink;
 }
 
-function replaceHtmlWithExternalLinks(html: string): string {
-  return html.replace(/<a.*href=".*">/gm, (match: string): string => {
+export function replaceHtmlWithExternalLinks(html: string): string {
+  return html.replace(/<a.*href=".*".*>/gm, (match: string): string => {
     if (match.includes('target="_blank"')) return match;
-    return match.replace(/target=“_.*”/g, '').slice(0, match.length - 1) + ' target="_blank">';
+    match = match.replace(/target="_.*"/g, '');
+    return match.slice(0, match.length - 1) + ' target="_blank">';
   });
 }
 

--- a/src/lib/ical/utils.ts
+++ b/src/lib/ical/utils.ts
@@ -151,7 +151,7 @@ export function produceSummary(title: string, description: string, selfLink: str
 }
 
 export function replaceHtmlWithExternalLinks(html: string): string {
-  return html.replace(/<a.*href=".*".*>/gm, (match: string): string => {
+  return html.replace(/<a .*href=".*".*>/gm, (match: string): string => {
     if (match.includes('target="_blank"')) return match;
     match = match.replace(/target=".*?"\W*/g, '');
     return match.slice(0, match.length - 1) + ' target="_blank">';

--- a/src/lib/ical/utils.ts
+++ b/src/lib/ical/utils.ts
@@ -150,6 +150,13 @@ export function produceSummary(title: string, description: string, selfLink: str
     : title + ' — ' + selfLink;
 }
 
+function assertHtmlHasAllExternalLinks(html: string): string {
+  return html.replace(/<a.*href=".*">/gm, (match: string): string => {
+    if (match.includes('target="_blank"')) return match;
+    return match.replace(/target=“_.*”/g, '').slice(0, match.length - 1) + ' target="_blank">';
+  });
+}
+
 export function parseDescription(
   content?: string,
   varPrefix = 'ACM_'
@@ -181,6 +188,8 @@ export function parseDescription(
     variables.set(key, value);
     description = (description.substring(0, start) + description.substring(end)).trim();
   }
+
+  description = assertHtmlHasAllExternalLinks(description);
 
   return { description, variables };
 }


### PR DESCRIPTION
Fix for issue 346. Added a function named replaceHtmlWithExternalLinks in utils.ts that parses through any anchor tags and sets the target attribute to _blank. This will open up any links found within the description of an event in a new tab. Additional tests were also added to utils.test.ts that checked for the correctness of this function.