### PR TITLE
"This week's event" changed to "Upcoming Events"

### DIFF
--- a/src/routes/events/index.svelte
+++ b/src/routes/events/index.svelte
@@ -33,7 +33,7 @@
 
 <Spacing --min="100px" --med="175px" --max="200px" />
 
-<h2 class="size-lg headers">This week's events 📅</h2>
+<h2 class="size-lg headers">Upcoming events 📅</h2>
 
 <Spacing --med="16px" />
 


### PR DESCRIPTION
Changed the title of events page to accommodate for additional events added that go past the week.

Resolves #441. 