### PR TITLE
Fix/277 Allow users to filter the posts by tags.

### DIFF
--- a/src/lib/components/utils/acm-tagfield.svelte
+++ b/src/lib/components/utils/acm-tagfield.svelte
@@ -1,0 +1,106 @@
+<script lang="ts">
+  export let tags: string[] = [];
+  export let selected: string[] = [];
+  export let label: string = '';
+  export let resetButton: string = '';
+  export let onChange: (tags: string[]) => void;
+  let hasSelectedTags = false;
+
+  function selectTag(event: any) {
+    if (selected.includes(event.target.innerText)) {
+      selected = selected.filter((t) => t !== event.target.innerText);
+    } else {
+      selected.push(event.target.innerText);
+    }
+
+    event.target.classList.toggle('selected');
+    hasSelectedTags = selected.length > 0;
+    onChange(selected);
+  }
+
+  function clearFilter() {
+    selected = [];
+    hasSelectedTags = false;
+    onChange(selected);
+  }
+</script>
+
+<div class="tag-box">
+  <div class="tag-title" class:hidden={hasSelectedTags}>{label}</div>
+  <div class="tag-clear-button" class:hidden={!hasSelectedTags} on:click={clearFilter}>
+    {resetButton}
+  </div>
+  <div class="tag-list">
+    {#each tags as tag}
+      <div class="tag" class:selected={selected.includes(tag)} on:click={selectTag}>
+        {tag}
+      </div>
+    {/each}
+  </div>
+</div>
+
+<style lang="scss">
+  .tag-box {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    .tag-title {
+      font-size: 1em;
+      font-weight: bold;
+      margin-right: 1em;
+      cursor: default;
+    }
+    .hidden {
+      display: none;
+    }
+    .tag-clear-button {
+      margin-right: 1em;
+      font-size: small;
+      color: #424242;
+      text-decoration: underline;
+      cursor: pointer;
+    }
+    .tag-list {
+      display: flex;
+      flex-wrap: wrap;
+      justify-content: center;
+      // justify-content: space-around;
+      .tag {
+        margin-bottom: 0.2em;
+        margin-right: var(--size-sm);
+        padding: 0.25em 0.8em 0.25em 0.8em;
+        background-color: #eeeeee;
+        color: #212121;
+        border-radius: var(--size-sm);
+        border: 2px solid #e0e0e0;
+        cursor: pointer;
+        transition: 0.25s ease-in-out;
+
+        &:hover {
+          // background-color: #b0bec5;
+          border-color: #b0bec5;
+        }
+
+        &.selected {
+          transition: 1s ease-in-out;
+          background-color: #81d4fa;
+          border-color: #4fc3f7;
+          &:before {
+            content: '✓ ';
+          }
+          &:hover {
+            border-color: #2196f3;
+          }
+        }
+      }
+    }
+    @media screen and (max-width: 900px) {
+      .tag-title {
+        display: none;
+      }
+      .tag-clear-button {
+        display: none;
+      }
+    }
+  }
+</style>

--- a/src/lib/components/utils/acm-tagfield.svelte
+++ b/src/lib/components/utils/acm-tagfield.svelte
@@ -1,10 +1,13 @@
 <script lang="ts">
+  import { createEventDispatcher } from 'svelte';
+
   export let tags: string[] = [];
   export let selected: string[] = [];
-  export let label: string = '';
-  export let resetButton: string = '';
-  export let onChange: (tags: string[]) => void;
-  let hasSelectedTags = false;
+  export let label = '';
+  export let resetButton = '';
+
+  const dispatch = createEventDispatcher();
+  let hasSelectedTags = selected.length > 0;
 
   function selectTag(event: any) {
     if (selected.includes(event.target.innerText)) {
@@ -15,13 +18,13 @@
 
     event.target.classList.toggle('selected');
     hasSelectedTags = selected.length > 0;
-    onChange(selected);
+    dispatch('change', selected);
   }
 
   function clearFilter() {
     selected = [];
     hasSelectedTags = false;
-    onChange(selected);
+    dispatch('change', selected);
   }
 </script>
 

--- a/src/routes/blog/_query.ts
+++ b/src/routes/blog/_query.ts
@@ -98,7 +98,7 @@ function formatNewsletters(output: any): Newsletter[] {
   });
 }
 
-export async function fetchNewsletters(options: NewsletterFetchOptions): Promise<Newsletter[]> {
+export async function fetchNewsletters(options?: NewsletterFetchOptions): Promise<Newsletter[]> {
   const ghAccessToken = import.meta.env.VITE_GH_ACCESS_TOKEN;
 
   const response = await fetch('https://api.github.com/graphql', {

--- a/src/routes/blog/_query.ts
+++ b/src/routes/blog/_query.ts
@@ -17,6 +17,10 @@ export interface Newsletter {
   };
 }
 
+export interface NewsletterFetchOptions {
+  labels: string[];
+}
+
 /**
  * GraphQL query to get all the blog posts from the newsletters category.
  * @see https://docs.github.com/en/graphql/overview/explorer
@@ -94,7 +98,7 @@ function formatNewsletters(output: any): Newsletter[] {
   });
 }
 
-export async function fetchNewsletters(): Promise<Newsletter[]> {
+export async function fetchNewsletters(options: NewsletterFetchOptions): Promise<Newsletter[]> {
   const ghAccessToken = import.meta.env.VITE_GH_ACCESS_TOKEN;
 
   const response = await fetch('https://api.github.com/graphql', {
@@ -104,5 +108,9 @@ export async function fetchNewsletters(): Promise<Newsletter[]> {
   });
 
   const newsletters = formatNewsletters(await response.json());
-  return newsletters;
+  if (!options.labels.length) {
+    return newsletters;
+  } else {
+    return newsletters.filter((post) => post.labels.some((item) => options.labels.includes(item)));
+  }
 }

--- a/src/routes/blog/index.json.ts
+++ b/src/routes/blog/index.json.ts
@@ -1,8 +1,14 @@
-import type { RequestHandlerOutput } from '@sveltejs/kit/types/internal';
-import { fetchNewsletters } from './_query';
+import type { RequestHandlerOutput, RequestEvent } from '@sveltejs/kit/types/internal';
+import { fetchNewsletters, NewsletterFetchOptions } from './_query';
 
-export async function get(): Promise<RequestHandlerOutput> {
-  return new Response(JSON.stringify(await fetchNewsletters()), {
+export async function get(event: RequestEvent): Promise<RequestHandlerOutput> {
+  let fetchOptions: NewsletterFetchOptions = { labels: [] };
+
+  if (event.url.searchParams.has('l') === true && event.url.searchParams.get('l').length > 0) {
+    fetchOptions.labels = event.url.searchParams.get('l').split(',');
+  }
+
+  return new Response(JSON.stringify(await fetchNewsletters(fetchOptions)), {
     status: 200,
     headers: { 'Content-Type': 'application/json' },
   });

--- a/src/routes/blog/index.json.ts
+++ b/src/routes/blog/index.json.ts
@@ -2,7 +2,7 @@ import type { RequestHandlerOutput, RequestEvent } from '@sveltejs/kit/types/int
 import { fetchNewsletters, NewsletterFetchOptions } from './_query';
 
 export async function get(event: RequestEvent): Promise<RequestHandlerOutput> {
-  let fetchOptions: NewsletterFetchOptions = { labels: [] };
+  const fetchOptions: NewsletterFetchOptions = { labels: [] };
 
   if (event.url.searchParams.has('l') === true && event.url.searchParams.get('l').length > 0) {
     fetchOptions.labels = event.url.searchParams.get('l').split(',');

--- a/src/routes/blog/index.svelte
+++ b/src/routes/blog/index.svelte
@@ -1,8 +1,12 @@
 <script lang="ts" context="module">
   import type { LoadInput, LoadOutput } from '@sveltejs/kit/types/internal';
 
-  export async function load({ fetch }: LoadInput): Promise<LoadOutput> {
-    const response = await fetch(`/blog.json`);
+  export async function load(event: LoadInput): Promise<LoadOutput> {
+    const target = new URL('/blog.json', event.url);
+    if (event.url.searchParams.has('l')) {
+      target.searchParams.set('l', event.url.searchParams.get('l'));
+    }
+    const response = await fetch(target.toString());
     return { props: { posts: await response.json() } };
   }
 </script>
@@ -30,6 +34,13 @@
   </h2>
 
   <Spacing --min="100px" --med="175px" --max="200px" />
+
+  <div>
+    [Testing] Filter by Tag:
+    <a title="" href="?l=algo">algo</a>
+    <a title="" href="?l=release">release</a>
+    <a title="" href="?l=algo,release">algo & release</a>
+  </div>
 
   <ul>
     {#each posts as post (post.id)}

--- a/src/routes/blog/index.svelte
+++ b/src/routes/blog/index.svelte
@@ -2,6 +2,7 @@
   import type { LoadInput, LoadOutput } from '@sveltejs/kit/types/internal';
   import TagField from '$lib/components/utils/acm-tagfield.svelte';
 
+  let allTags = ['algo', 'release']; // TODO: get tags from backend
   let selectedTags: string[] = [];
 
   export async function load(event: LoadInput): Promise<LoadOutput> {
@@ -25,17 +26,21 @@
 
   export let posts: Newsletter[] = [];
 
-  async function filterPosts(tags: string[]) {
+  async function filterPosts(event: CustomEvent) {
+    const tags = event.detail;
+
     window.history.replaceState({}, '', `${window.location.pathname}?l=${tags.join(',')}`);
+
     const target = new URL('/blog.json', window.location.origin);
     target.searchParams.set('l', tags.join(','));
+
     const response = await fetch(target.toString());
     posts = await response.json();
   }
 </script>
 
 <svelte:head>
-  <title>acmCSUF / README</title>
+  <title>Blog | ACM at CSUF</title>
 </svelte:head>
 
 <Spacing --min="175px" --med="200px" --max="200px" />
@@ -52,9 +57,9 @@
   <Spacing --min="100px" --med="175px" --max="200px" />
 
   <TagField
-    tags={['algo', 'release', 'news', 'announcement', 'event', 'workshop', 'talk']}
+    tags={allTags}
     selected={selectedTags}
-    onChange={filterPosts}
+    on:change={filterPosts}
     label="Filter by Tags"
     resetButton="✖ Clear Filter"
   />


### PR DESCRIPTION
Quick description: Allow users to filter the posts by tags.

* Created TagField Component
	File Location: src/lib/components/utils/acm-tagfield.svelte
	Usage: Allows users to make selections and filter content.
* Added Filter by Tags feature for Blog page.	
	Made some changes to these files:
	- In blog/index.svelte: Added TagField component.
	- In blog/_query.ts: Modified fetchNewsletters.
	- In blog/index.json.ts: Modified get function.