### PR TITLE
Removed `DEBUG` from parse()

### DIFF
--- a/src/lib/ical/parse.ts
+++ b/src/lib/ical/parse.ts
@@ -1,5 +1,4 @@
 import { Temporal } from '@js-temporal/polyfill';
-import { DEBUG } from '$lib/constants';
 import { walkICAL, makeAcmEvent, AcmEvent } from './utils';
 
 export interface ICALParseOptions {

--- a/src/lib/ical/parse.ts
+++ b/src/lib/ical/parse.ts
@@ -1,19 +1,28 @@
 import { Temporal } from '@js-temporal/polyfill';
 import { DEBUG } from '$lib/constants';
-import { walkICAL, makeAcmEvent, AcmEvent, ICALParseOptions } from './utils';
+import { walkICAL, makeAcmEvent, AcmEvent } from './utils';
+
+export interface ICALParseOptions {
+  filterBefore?: boolean;
+  referenceDate?: Temporal.ZonedDateTimeLike;
+  maxEvents?: number;
+}
 
 export function parse(rawICAL: string, options?: ICALParseOptions): AcmEvent[] {
   const acmEvents: AcmEvent[] = [];
 
   const refDate = options.referenceDate ?? Temporal.Now.zonedDateTimeISO('America/Los_Angeles');
+  const filterBefore = options.filterBefore !== undefined ? options.filterBefore : true;
 
   for (const icalEvent of walkICAL(rawICAL)) {
     const acmEvent = makeAcmEvent(icalEvent, refDate);
 
     // skip events that have already ended (except when in debug mode)
-    if (!acmEvent.hasEnded || DEBUG) {
-      acmEvents.push(acmEvent);
+    if (filterBefore && acmEvent.hasEnded) {
+      continue;
     }
+
+    acmEvents.push(acmEvent);
   }
 
   const sortedAcmEvents = acmEvents.sort((one, two) =>
@@ -22,8 +31,9 @@ export function parse(rawICAL: string, options?: ICALParseOptions): AcmEvent[] {
 
   // serve a set amount of events when in debug mode
   // @see <https://etok.codes/acmcsuf.com/pull/329>
-  if (DEBUG) {
-    return sortedAcmEvents.slice(-1 * (options.maxEvents ?? 5));
+  if (options.maxEvents !== undefined) {
+    const eventsAmt = options.maxEvents ?? 5;
+    return sortedAcmEvents.slice(0, eventsAmt);
   }
 
   return sortedAcmEvents;

--- a/src/lib/ical/utils.ts
+++ b/src/lib/ical/utils.ts
@@ -28,11 +28,6 @@ export interface AcmEvent {
 
 export type ICALResolvable = string | string[] | ICALResolvable[] | { [k: string]: ICALResolvable };
 
-export interface ICALParseOptions {
-  referenceDate?: Temporal.ZonedDateTimeLike;
-  maxEvents?: number;
-}
-
 /**
  * The code in this function is derived from
  * <https://github.com/adrianlee44/ical2json>.

--- a/src/routes/events/_index.test.ts
+++ b/src/routes/events/_index.test.ts
@@ -19,6 +19,11 @@ test('can find the correct page title', () => {
 test('renders 10 event items', async () => {
   const MAX_EVENTS = 10;
   const TEST_DATA = readFileSync('./src/routes/events/_testdata/events.ics', 'utf-8');
-  const { container } = render(Events, { events: parse(TEST_DATA, { maxEvents: MAX_EVENTS }) });
+  const { container } = render(Events, {
+    events: parse(TEST_DATA, {
+      maxEvents: MAX_EVENTS,
+      filterBefore: false,
+    }),
+  });
   expect(container.querySelectorAll('.event-box').length).toBe(MAX_EVENTS);
 });


### PR DESCRIPTION
The `maxEvents` option is sufficiently determined outside the `parse` function using the `DEBUG` constant variable. Therefore, there is no need to refer to `DEBUG` from within `parse()`.

- Added `filterBefore` [before reference date] option to `ICALParseOptions` (`true` by default).
- Moved `ICALParseOptions` interface into `/src/lib/ical/parse.ts`.

This PR is intended to resolve #464.