### PR TITLE
Removed calendar emoji and replaced with blue calendar SVG

### DIFF
--- a/src/routes/events/index.svelte
+++ b/src/routes/events/index.svelte
@@ -65,8 +65,8 @@
     img {
       display: block;
       margin-left: 10px;
-      width: 48px;
-      height: 48px;
+      width: 30px;
+      height: 30px;
     }
   }
 

--- a/src/routes/events/index.svelte
+++ b/src/routes/events/index.svelte
@@ -18,14 +18,14 @@
 </script>
 
 <svelte:head>
-  <title>Events | ACM at CSUF</title>
+  <title>Events / ACM at CSUF</title>
 </svelte:head>
 
 <Spacing --min="175px" --med="200px" --max="200px" />
 
 <CommonHero>
   <h2 slot="headline" class="size-lg">Curated events for growth and success</h2>
-  <p slot="text" class="size-xs">
+  <p slot="text" class="size-md">
     Our student chapter hosts a multitude of events throughout each school semester, consisting of
     workshops, info sessions, community building events, and much more!
     <br /><br />
@@ -37,7 +37,10 @@
 
 <Spacing --min="100px" --med="175px" --max="200px" />
 
-<h2 class="size-lg headers">Upcoming Events 📅</h2>
+<div class="main-header">
+  <h2 class="size-lg headers">Upcoming Events</h2>
+  <img src="assets/bluecalender.svg" alt="Blue Calender" />
+</div>
 
 <Spacing --med="16px" />
 
@@ -52,13 +55,30 @@
 <Spacing --min="8px" --med="63px" --max="88px" />
 
 <style lang="scss">
-  h2 {
+  .main-header {
     display: flex;
     justify-content: center;
     text-align: center;
+    align-items: center;
+    flex-direction: row;
+
+    img {
+      display: block;
+      margin-left: 10px;
+      width: 48px;
+      height: 48px;
+    }
   }
 
   p {
     text-align: center;
+  }
+
+  @media (max-width: 300px) {
+    .main-header {
+      img {
+        display: none;
+      }
+    }
   }
 </style>

--- a/static/assets/bluecalender.svg
+++ b/static/assets/bluecalender.svg
@@ -1,0 +1,14 @@
+<svg width="400" height="400" viewBox="0 0 400 400" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect x="7.5" y="7.5" width="385" height="385" rx="67.5" fill="#D5D5D5" stroke="#878787" stroke-width="15"/>
+<path d="M0 75C0 33.5786 33.5786 0 75 0H325C366.421 0 400 33.5786 400 75V100H0V75Z" fill="#2C91C6"/>
+<path d="M0 75C0 33.5786 33.5786 0 75 0H325C366.421 0 400 33.5786 400 75V100H0V75Z" stroke="#878787"/>
+<rect x="77" y="125" width="48" height="48" fill="#878787"/>
+<rect x="275" y="295" width="48" height="48" fill="#878787"/>
+<rect x="275" y="210" width="48" height="48" fill="#2C91C6"/>
+<rect x="275" y="125" width="48" height="48" fill="#878787"/>
+<rect x="176" y="295" width="48" height="48" fill="#878787"/>
+<rect x="176" y="210" width="48" height="48" fill="#878787"/>
+<rect x="176" y="125" width="48" height="48" fill="#878787"/>
+<rect x="77" y="295" width="48" height="48" fill="#878787"/>
+<rect x="77" y="210" width="48" height="48" fill="#878787"/>
+</svg>


### PR DESCRIPTION
Replaced calendar emoji with blue calendar SVG. The blue calendar was made using Figma so that the color could be matched to the acmBlue. The calendar will be hidden when the size of the screen decreases to a significant amount.


| Mode | Before | After|
| --- | --- | --- |
| Light | ![image](https://user-images.githubusercontent.com/60043611/168452735-b7cf1c38-3259-4ffa-883a-df3ddf6749e7.png) | ![image](https://user-images.githubusercontent.com/60043611/168452742-089eeeb6-e078-4383-be47-9e307b59c1b0.png) |
| Dark | ![image](https://user-images.githubusercontent.com/60043611/168452747-f0605236-c4e7-426f-85a2-1b3ea0ad5fd1.png) | ![image](https://user-images.githubusercontent.com/60043611/168452751-64d43f88-19c6-4825-b075-49619421cffa.png) |

Fixed #467 