### PR TITLE
fade bottom edge of blog preview

### DIFF
--- a/src/routes/blog/index.svelte
+++ b/src/routes/blog/index.svelte
@@ -152,6 +152,7 @@
             max-height: 100px;
             overflow: hidden;
             margin: 16px 0;
+            mask-image: linear-gradient(to bottom, black 50%, transparent 100%);
           }
         }
 

--- a/src/routes/blog/index.svelte
+++ b/src/routes/blog/index.svelte
@@ -153,6 +153,7 @@
             overflow: hidden;
             margin: 16px 0;
             mask-image: linear-gradient(to bottom, black 50%, transparent 100%);
+            -webkit-mask-image: linear-gradient(to bottom, black 50%, transparent 100%);
           }
         }
 


### PR DESCRIPTION
Just a 1 liner css property to fade the bottom edge of the blog preview as per @karnikaavelumani suggestion
![image](https://user-images.githubusercontent.com/8981287/172725319-25768f5a-a075-40ec-a183-ac2769031153.png)

Looks like this
![image](https://user-images.githubusercontent.com/8981287/172725341-154b1d61-6f0c-4696-97f9-ed12f7188bcc.png)
