### PR TITLE
Refactored caching logic for individual blog posts

### DIFF
--- a/src/routes/blog/[id].json.ts
+++ b/src/routes/blog/[id].json.ts
@@ -4,7 +4,7 @@ import type { Newsletter } from './_query';
 async function getCache(id: number, origin: string) {
   const target = new URL('/blog.json', origin);
 
-  const response = await fetch(target);
+  const response = await fetch(target.toString());
   const payload = await response.json();
 
   if (payload.posts && payload.posts.length > 0) {

--- a/src/routes/blog/[id].json.ts
+++ b/src/routes/blog/[id].json.ts
@@ -2,18 +2,14 @@ import type { RequestEvent, RequestHandlerOutput } from '@sveltejs/kit/types/int
 import type { Newsletter } from './_query';
 
 async function getCache(id: number, origin: string) {
-  const target = origin + `/blog.json`;
+  const target = new URL('/blog.json', origin);
 
-  try {
-    const response = await fetch(target);
-    const data = await response.json();
-    const newsletter = (data as Newsletter[]).find((item) => {
-      return item.id === id;
-    });
-    return newsletter;
-  } catch (err) {
-    console.error(err);
-    return undefined;
+  const response = await fetch(target);
+  const payload = await response.json();
+
+  if (payload.posts && payload.posts.length > 0) {
+    const posts = payload.posts as Newsletter[];
+    return posts.find((item) => item.id === id);
   }
 }
 


### PR DESCRIPTION
This PR slightly improves the caching technique for individual blog post JSON endpoints which are used by individual blog post pages. 

Note: This may change in the fix for #502.
