### PR TITLE
deprecate nodebuds

### DIFF
--- a/src/lib/components/sections/navbar.svelte
+++ b/src/lib/components/sections/navbar.svelte
@@ -13,7 +13,6 @@
     { title: 'About', path: '/about' },
     { title: 'Events', path: '/events' },
     { title: 'Teams', path: '/teams' },
-    { title: 'Node Buds', path: '/nodebuds' },
     { title: 'Blog', path: '/blog' },
   ];
 


### PR DESCRIPTION
only removing from navbar but keeping the page in the event we ever want to bring it back

<img width="1388" alt="image" src="https://user-images.githubusercontent.com/8981287/187278555-2b6d51db-f1dc-4760-a680-4940ad138854.png">

<img width="449" alt="image" src="https://user-images.githubusercontent.com/8981287/187278583-333474ac-3cd8-4e6c-8c44-bd89e0e973c1.png">

