### PR TITLE
Adjusted 'ready-up.svelte' from 800+ members to 1000+ members

### DIFF
--- a/src/lib/components/index/ready-up.svelte
+++ b/src/lib/components/index/ready-up.svelte
@@ -15,7 +15,7 @@
         <br /><br />
 
         <span class="brand-med">
-          Our chapter of 800+ members is forever free and open for anyone to join, regardless of
+          Our chapter of 1000+ members is forever free and open for anyone to join, regardless of
           major or technical ability.
         </span>
       </p>


### PR DESCRIPTION
Adjusted line 18 in "ready-up.svelte" to read "1000+ members" instead of "800+ members", because the ACM discord now shows that we have 1000+ active members.

From this:
![image](https://user-images.githubusercontent.com/10971284/189575879-05c747c4-2a6a-4dba-9c27-5685d6f9597d.png)
To This:
![image](https://user-images.githubusercontent.com/10971284/189575914-dfa752a3-9206-4df7-af13-fe68327a54eb.png)

[Link to Issue #534](https://github.com/EthanThatOneKid/acmcsuf.com/issues/534) 

// Ignore the poor zoom
