### PR TITLE
SvelteKit release candidate migration: service-worker 

### DIFF
--- a/src/service-worker/activate.ts
+++ b/src/service-worker/activate.ts
@@ -1,0 +1,13 @@
+/// <reference lib="webworker" />
+import { CURRENT_CACHE_NAME } from './common';
+
+export function handleActivate(event: ExtendableEvent): void {
+  event.waitUntil(
+    caches.keys().then((cacheNames) =>
+      Promise.all(
+        // Delete old caches with an expired cache name
+        cacheNames.map((cacheName) => cacheName !== CURRENT_CACHE_NAME && caches.delete(cacheName))
+      )
+    )
+  );
+}

--- a/src/service-worker/common.ts
+++ b/src/service-worker/common.ts
@@ -1,0 +1,4 @@
+import { build, files, version } from '$service-worker';
+
+export const CURRENT_CACHE_NAME = 'acmcsuf-' + version;
+export const BUILD_FILES = build.concat(files);

--- a/src/service-worker/fetch.ts
+++ b/src/service-worker/fetch.ts
@@ -1,0 +1,7 @@
+/// <reference lib="webworker" />
+
+export function handleFetch(event: FetchEvent): void {
+  // If online, try to fetch from network with a timeout.
+  // If anything fails, try to serve from cache.
+  event.respondWith(fetch(event.request));
+}

--- a/src/service-worker/index.ts
+++ b/src/service-worker/index.ts
@@ -1,0 +1,25 @@
+/// <reference lib="webworker" />
+/* eslint-disable no-var */
+/* eslint-disable @typescript-eslint/naming-convention */
+
+import { handleActivate } from './activate';
+import { handleInstall } from './install';
+import { handleFetch } from './fetch';
+
+// has to be var, because we need function scope
+declare var self: ServiceWorkerGlobalScope;
+
+/**
+ * Takes care of the installation of the service worker, as well as the creation of the cache.
+ */
+self.addEventListener('install', handleInstall);
+
+/**
+ * Intercepts requests made by the page so we can decide what to do with each one.
+ */
+self.addEventListener('fetch', handleFetch);
+
+/**
+ * Takes care of the activation of the service worker, as well as the deletion of old caches.
+ */
+self.addEventListener('activate', handleActivate);

--- a/src/service-worker/install.ts
+++ b/src/service-worker/install.ts
@@ -1,0 +1,16 @@
+/// <reference lib="webworker" />
+import { CURRENT_CACHE_NAME } from './common';
+import { build } from '$service-worker';
+
+export function handleInstall(event: ExtendableEvent): void {
+  event.waitUntil(
+    // Cache known build output and static files
+    // @see <https://kit.svelte.dev/docs/modules#$service-worker-build>
+    caches.open(CURRENT_CACHE_NAME).then((cache) => {
+      // Open a cache and cache our files
+      cache.addAll(build);
+
+      return true;
+    })
+  );
+}


### PR DESCRIPTION
This feature allows users to install our website to get info about ACM at CSUF while offline. There are no migration instructions for migrating the service worker in <https://github.com/sveltejs/kit/discussions/5774>. I referred to this example: <https://github.com/Myrmod/SvelteKit-offline/blob/c8cd6874c16bc838732189b0c4476b88f1a00bc0/src/service-worker/index.ts>.