### PR TITLE
Added more space between blog post HTML elements

### DIFF
--- a/src/routes/(site)/blog/[id]/blog-body.svelte
+++ b/src/routes/(site)/blog/[id]/blog-body.svelte
@@ -12,9 +12,16 @@
   .blog-body {
     text-align: left;
 
-    :global(p) {
-      margin-bottom: 16px;
+    :global(p),
+    :global(h1),
+    :global(h2),
+    :global(h3),
+    :global(h4),
+    :global(h5),
+    :global(h6) {
+      margin: 1.5rem 0 0.5rem;
     }
+
     :global(code),
     :global(pre) {
       font-family: monospace;
@@ -24,13 +31,25 @@
       overflow: auto;
       margin: 0.5em 0;
     }
+
     :global(pre) {
       padding: 16px;
     }
+
     :global(code) {
       border-radius: 0.3em;
       padding: 0.1em 0.5em;
       margin: 0 0.3em;
+    }
+
+    :global(ul),
+    :global(ol) {
+      margin: 1.5rem 0 0.5rem;
+      padding-left: 1.5rem;
+    }
+
+    :global(hr) {
+      margin: 2rem 0;
     }
   }
 </style>

--- a/src/routes/(site)/blog/[id]/blog-body.svelte
+++ b/src/routes/(site)/blog/[id]/blog-body.svelte
@@ -32,6 +32,12 @@
       margin: 0.5em 0;
     }
 
+    :global(blockquote) {
+      margin: 0;
+      padding: 0 1em;
+      border-left: 0.25em solid #d0d7de;
+    }
+
     :global(pre) {
       padding: 16px;
     }

--- a/src/routes/(site)/blog/[id]/blog-body.svelte
+++ b/src/routes/(site)/blog/[id]/blog-body.svelte
@@ -39,7 +39,7 @@
     }
 
     :global(pre) {
-      padding: 16px;
+      padding: 1em;
     }
 
     :global(code) {

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -11,7 +11,7 @@
 
   $: if (browser) {
     send({
-      id: "$VERCEL_ANALYTICS_ID",
+      id: '$VERCEL_ANALYTICS_ID',
       path: $page.url.pathname,
       params: $page.params,
       navigator,

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -6,9 +6,7 @@ const config = {
   // Consult https://github.com/sveltejs/svelte-preprocess
   // for more information about preprocessors
   preprocess: preprocess({
-    replace: [
-      ['$VERCEL_ANALYTICS_ID', process.env.VERCEL_ANALYTICS_ID],
-    ],
+    replace: [['$VERCEL_ANALYTICS_ID', process.env.VERCEL_ANALYTICS_ID]],
   }),
 
   kit: {


### PR DESCRIPTION
The `acmcsuf.com/blog` uses HTML generated by GitHub from markdown hosted on GitHub Discussions.

We could import the markdown CSS used by GitHub, but there is no point in closely matching the style of our blog pages with GitHub's markdown CSS. For this reason the `src/routes/(site)/blog/[id]/blog-body.svelte` file consolidates all of the custom styles that we use for our blog post HTML.

To accomplish this, the code below selects any paragraph or header element in the blog post HTML and gives it a standard custom margin.
```css
 :global(p),
 :global(h1),
 :global(h2),
 :global(h3),
 :global(h4),
 :global(h5),
 :global(h6) {
    margin: 1.5rem 0 0.5rem;
 }
```

Intended to resolve #614.