### PR TITLE
Remove Vercel Audiences

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "3.0.0",
       "dependencies": {
         "@js-temporal/polyfill": "^0.4.1",
-        "@vercel/analytics": "^0.1.3",
         "html-to-text": "^8.2.1",
         "qrcode": "^1.5.1",
         "rrule": "^2.6.9",
@@ -751,14 +750,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@vercel/analytics": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@vercel/analytics/-/analytics-0.1.3.tgz",
-      "integrity": "sha512-zJuEwzvi0bBmWrMrj9jvyMS+X6iUdW3m/y5P7aOLwJQKHsJyfpdINo/4Rv+wxubz3gl4nRqIQdtOFCe1P1ErXQ==",
-      "peerDependencies": {
-        "react": "^16.8||^17||^18"
       }
     },
     "node_modules/@vercel/nft": {
@@ -2561,12 +2552,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/js-tokens": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "peer": true
-    },
     "node_modules/js-yaml": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
@@ -2659,18 +2644,6 @@
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
-    },
-    "node_modules/loose-envify": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
-      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "peer": true,
-      "dependencies": {
-        "js-tokens": "^3.0.0 || ^4.0.0"
-      },
-      "bin": {
-        "loose-envify": "cli.js"
-      }
     },
     "node_modules/loupe": {
       "version": "2.3.4",
@@ -3319,18 +3292,6 @@
       },
       "engines": {
         "node": ">=0.12"
-      }
-    },
-    "node_modules/react": {
-      "version": "18.2.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
-      "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
-      "peer": true,
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/readable-stream": {
@@ -5095,12 +5056,6 @@
         "eslint-visitor-keys": "^3.3.0"
       }
     },
-    "@vercel/analytics": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@vercel/analytics/-/analytics-0.1.3.tgz",
-      "integrity": "sha512-zJuEwzvi0bBmWrMrj9jvyMS+X6iUdW3m/y5P7aOLwJQKHsJyfpdINo/4Rv+wxubz3gl4nRqIQdtOFCe1P1ErXQ==",
-      "requires": {}
-    },
     "@vercel/nft": {
       "version": "0.22.1",
       "resolved": "https://registry.npmjs.org/@vercel/nft/-/nft-0.22.1.tgz",
@@ -6451,12 +6406,6 @@
         "istanbul-lib-report": "^3.0.0"
       }
     },
-    "js-tokens": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "peer": true
-    },
     "js-yaml": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
@@ -6525,15 +6474,6 @@
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
-    },
-    "loose-envify": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
-      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "peer": true,
-      "requires": {
-        "js-tokens": "^3.0.0 || ^4.0.0"
-      }
     },
     "loupe": {
       "version": "2.3.4",
@@ -6966,15 +6906,6 @@
       "requires": {
         "discontinuous-range": "1.0.0",
         "ret": "~0.1.10"
-      }
-    },
-    "react": {
-      "version": "18.2.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
-      "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
-      "peer": true,
-      "requires": {
-        "loose-envify": "^1.1.0"
       }
     },
     "readable-stream": {

--- a/package.json
+++ b/package.json
@@ -63,7 +63,6 @@
   "type": "module",
   "dependencies": {
     "@js-temporal/polyfill": "^0.4.1",
-    "@vercel/analytics": "^0.1.3",
     "html-to-text": "^8.2.1",
     "qrcode": "^1.5.1",
     "rrule": "^2.6.9",

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -5,24 +5,17 @@
   //
   // https://kit.svelte.dev/docs/advanced-routing#advanced-layouts
 
-  import { inject } from '@vercel/analytics';
   import { page } from '$app/stores';
   import { browser, dev } from '$app/environment';
   import { VERCEL_ANALYTICS_ID } from '$env/static/public';
   import { send } from '$lib/public/analytics/vitals';
 
   $: if (browser && !dev && VERCEL_ANALYTICS_ID) {
-    inject({
-      beforeSend() {
-        send({
-          id: VERCEL_ANALYTICS_ID,
-          path: $page.url.pathname,
-          params: $page.params,
-          navigator,
-        });
-
-        return null;
-      },
+    send({
+      id: VERCEL_ANALYTICS_ID,
+      path: $page.url.pathname,
+      params: $page.params,
+      navigator,
     });
   }
 </script>

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -13,7 +13,7 @@
 
   $: if (browser && !dev && VERCEL_ANALYTICS_ID) {
     inject({
-      beforeSend(ev) {
+      beforeSend() {
         send({
           id: VERCEL_ANALYTICS_ID,
           path: $page.url.pathname,
@@ -21,7 +21,7 @@
           navigator,
         });
 
-        return ev;
+        return null;
       },
     });
   }

--- a/static/va/script.js
+++ b/static/va/script.js
@@ -1,4 +1,0 @@
-// Hoping Vercel provides an official /va/script.js soon.
-//
-// Related:
-// https://github.com/pyronaur/pyronaur.com/commit/4ad95042d7cd7e0b9d543d72e24193799b56e992


### PR DESCRIPTION
### Why?

1. Our previous Analytics were failing when in conjunction with the Audiences implementation.
2. There are no specific examples or instructions on implementing Vercel Audiences in a SvelteKit application.
3. One problem seems to be the mystery of the `/va/script.js` because I do not know where that is on the Internet, yet it seems to be required by `@vercel/analytics` despite finding zero documentation on the subject.

![No analytics](https://user-images.githubusercontent.com/31261035/199124204-e3fad6bd-fb54-4065-953e-0e5400d032e3.png)

### Future work

Perhaps I am missing something small, but I know that I must revert the Audiences changes in order to bring back our Vercel  Analytics and metrics. When new information is released by Vercel, it might be worth it to try reimplementing Vercel Audiences.