### PR TITLE
Make sure the buttons render correctly on dark mode

### DIFF
--- a/static/global.css
+++ b/static/global.css
@@ -174,9 +174,9 @@ body:has(nav > input[type='checkbox']:checked) {
   --navbar-bg: rgba(16, 19, 21, 0.9);
   --footer-bg: var(--acm-gray);
   --card-bg: var(--acm-gray);
-  --button-bg: var(--acm-dark);
+  --button-bg: var(--acm-gray);
   --button-hover: #3d4043;
-  --button-toggle: var(--acm-dark);
+  --button-toggle: var(--acm-gray);
   --box-shadow: var(--nav-shadow);
 }
 


### PR DESCRIPTION
Buttons do not render correctly in dark mode because the text and the background color of the button are both white. Changing --button-bg: var(--acm-gray); ( Changing the background color of the button to gray) will do the trick.
Possibly because some browser does not load the javascript for "--acm-dark" in .global.css correctly. Fixes #658 