### PR TITLE
Center the button groups in event for mobile

### DIFF
--- a/src/routes/(site)/events/event.svelte
+++ b/src/routes/(site)/events/event.svelte
@@ -322,5 +322,10 @@
       margin-bottom: 12px;
       margin-right: 0;
     }
+
+    .event-actionbar {
+      justify-content: center;
+      flex-direction: row;
+    }
   }
 </style>


### PR DESCRIPTION
Before:
![Inkedacmmobile](https://user-images.githubusercontent.com/54611122/199643340-98120bbd-3d2c-4f80-9deb-4e4d43dc55a4.jpg)

After:

https://user-images.githubusercontent.com/54611122/199643690-1eb626dc-f1a8-4ba3-bf06-d927d6162bd1.mp4

fixes #670 

