### PR TITLE
Fix properties of undefined regression in results screen

### DIFF
--- a/src/routes/(site)/events/event.svelte
+++ b/src/routes/(site)/events/event.svelte
@@ -322,10 +322,5 @@
       margin-bottom: 12px;
       margin-right: 0;
     }
-
-    .event-actionbar {
-      justify-content: center;
-      flex-direction: row;
-    }
   }
 </style>

--- a/src/routes/(site)/events/event.svelte
+++ b/src/routes/(site)/events/event.svelte
@@ -322,5 +322,10 @@
       margin-bottom: 12px;
       margin-right: 0;
     }
+
+    .event-actionbar {
+      justify-content: center;
+      flex-direction: row;
+    }
   }
 </style>

--- a/src/routes/(site)/quiz/quiz.svelte
+++ b/src/routes/(site)/quiz/quiz.svelte
@@ -57,7 +57,7 @@
   }
 
   $: talliedResponses = (responses ?? []).reduce((tallies, match) => {
-    match = match?.toLocaleLowerCase();
+    match = match?.toLowerCase();
     if (match && tallies[match]) tallies[match]++;
     else if (match) tallies[match] = 1;
     return tallies;

--- a/src/routes/(site)/quiz/quiz.svelte
+++ b/src/routes/(site)/quiz/quiz.svelte
@@ -57,6 +57,7 @@
   }
 
   $: talliedResponses = (responses ?? []).reduce((tallies, match) => {
+    match = match?.toLocaleLowerCase();
     if (match && tallies[match]) tallies[match]++;
     else if (match) tallies[match] = 1;
     return tallies;


### PR DESCRIPTION
The keys in the JSON object are lowercase as shown below
![quizconsole](https://user-images.githubusercontent.com/54611122/200098903-dfe24c56-eff9-48f7-b273-626eb418feea.png)

So calling toLowerCase() function on: 
![fix](https://user-images.githubusercontent.com/54611122/200098922-8bae12b7-f179-4a3e-978f-8be7147f8dd2.png)
(line 60 in quiz.svelte) will fix the undefined issue.
![acmquiz](https://user-images.githubusercontent.com/54611122/200098958-d3ab0e7f-8577-45fb-8100-ccaf6b6c605e.png)

fixes #673 