### PR TITLE
Vite: using import.meta.glob over import.meta.globEager

### DIFF
--- a/src/lib/public/confetti/frank.ts
+++ b/src/lib/public/confetti/frank.ts
@@ -1,1 +1,0 @@
-export default 'url(/assets/png/acm-shark.png)';

--- a/src/routes/(site)/1st/+page.svelte
+++ b/src/routes/(site)/1st/+page.svelte
@@ -1,6 +1,7 @@
 <script context="module" lang="ts">
-  const confetti: Record<string, { default: string }> = import.meta.globEager(
-    '$lib/1st/confetti/*.ts'
+  const confetti: Record<string, { default: string }> = import.meta.glob(
+    '$lib/public/confetti/*.ts',
+    { eager: true }
   );
 </script>
 


### PR DESCRIPTION
According to <https://vitejs.dev/guide/migration.html#import-meta-glob>,

> import.meta.globEager is now deprecated. Use import.meta.glob('*', { eager: true }) instead.

This migration has been implemented within the PR.

Resolves #642.