### PR TITLE
Removed the drop shadow from the blog/id pages. Issue 687

### DIFF
--- a/src/routes/(site)/blog/[id]/+page.svelte
+++ b/src/routes/(site)/blog/[id]/+page.svelte
@@ -76,10 +76,7 @@
     text-align: left;
     padding: 4em 4em 3em;
     margin: 0;
-    background-color: var(--acm-light);
     border-radius: 3em;
-    filter: drop-shadow(0 8px 40px rgba(16, 19, 21, 0.1));
-    -webkit-filter: drop-shadow(0 8px 40px rgba(16, 19, 21, 0.1));
     width: min(1000px, 70vw);
   }
   img {


### PR DESCRIPTION
- This resolution tackles the issue #687 that I created at Ethan's request. 
- I removed the drop-shadow + background-color to the container holding the blog in the blog/{id} page. This was brought to my attention by @jaasonw and an extension to @karnikaavelumani's issue #654 
- Only 3 lines of CSS were removed.

Before | After
---|---
![image](https://user-images.githubusercontent.com/10971284/200196738-096a6164-63d7-44c4-a00f-162aebac2ed0.png)|![image](https://user-images.githubusercontent.com/10971284/200198230-c8709a9f-621b-4b5a-b7cb-e53030d277b2.png)
