### PR TITLE
Fix alt text typo for button to copy Outlook link

### DIFF
--- a/src/routes/(site)/events/event.svelte
+++ b/src/routes/(site)/events/event.svelte
@@ -125,7 +125,7 @@
             info.team.id
           )}
       >
-        <BwIcon src="/assets/svg/outlook-calendar.svg" alt="Copy Outlink link" />
+        <BwIcon src="/assets/svg/outlook-calendar.svg" alt="Copy Outlook Calendar link" />
       </button>
     </div>
   </details>


### PR DESCRIPTION
Fix the alt text for now until the images are fixed (https://github.com/EthanThatOneKid/acmcsuf.com/issues/698)