### PR TITLE
Remove duplicate footer on all pages

### DIFF
--- a/src/routes/+error.svelte
+++ b/src/routes/+error.svelte
@@ -1,7 +1,11 @@
 <script lang="ts">
   import { page } from '$app/stores';
   import Button from '$lib/components/button/button.svelte';
+  import Bar from '$lib/components/nav/bar.svelte';
+  import Footer from '$lib/components/footer/footer.svelte';
 </script>
+
+<Bar />
 
 <svelte:head>
   <title>ACM at CSUF / {$page.status || 404}</title>
@@ -13,6 +17,8 @@
   <Button text={'Return to Home'} link={'/'} />
   <img src="/assets/png/lost-frank.png" alt="404 - Page Not Found" />
 </section>
+
+<Footer />
 
 <style>
   section {

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -4,10 +4,6 @@
   // layout of all pages.
   //
   // https://kit.svelte.dev/docs/advanced-routing#advanced-layouts
-  import Bar from '$lib/components/nav/bar.svelte';
-  import Footer from '$lib/components/footer/footer.svelte';
 </script>
 
-<Bar />
 <slot />
-<Footer />


### PR DESCRIPTION
Upon approving PR #718, I mistakenly did not notice a duplicate footer was created as a result. This is caused by importing the footer and navbar to the wrong file `+layout.svelte` as opposed to `+error.svelte`. 

It is important to note that `+layout.svelte` is a blank layout. Stated in the comments, this file is used by the pages that don't need a layout and is also used as the base layout of all pages. 

As mentioned in the svelte docs (https://kit.svelte.dev/docs/advanced-routing#advanced-layouts), "Pages and layouts inside groups — as in any other directory — will inherit layouts above them". I presume that the `+layout.svelte` file above this one may have caused the duplicate footer, since it also imports the navbar and footer.
<img width="171" alt="image" src="https://user-images.githubusercontent.com/60043611/201845262-6df03d24-a763-49ff-bc83-aaac32b24918.png">

Fixes #720.