### PR TITLE
Create new page for board applications

### DIFF
--- a/src/lib/components/recursive-ul/recursive-ul.svelte
+++ b/src/lib/components/recursive-ul/recursive-ul.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+  import type { ListItem } from './types';
+
+  export let data: ListItem[];
+</script>
+
+<ul class="recursive-ul">
+  {#each data as item}
+    <li class="recursive-ul__item">
+      {@html item.html}
+      {#if item.children}
+        <svelte:self data={item.children} />
+      {/if}
+    </li>
+  {/each}
+</ul>

--- a/src/lib/components/recursive-ul/types.ts
+++ b/src/lib/components/recursive-ul/types.ts
@@ -1,0 +1,4 @@
+export interface ListItem {
+  html: string;
+  children?: ListItem[];
+}

--- a/src/lib/components/recursive-ul/utils.ts
+++ b/src/lib/components/recursive-ul/utils.ts
@@ -1,0 +1,5 @@
+import type { ListItem } from './types';
+
+export function li(html: string, children?: ListItem[]): ListItem {
+  return { html, children };
+}

--- a/src/lib/public/board/data/index.ts
+++ b/src/lib/public/board/data/index.ts
@@ -17,7 +17,7 @@ export const TEAMS = [...TEAMS_JSON].reduce(
     tt[t.id] = t;
     return tt;
   },
-  {} as Record<keyof typeof TEAMS_JSON[number], Team>
+  {}
 );
 
 /** Pinned paths are featured on the landing page. */

--- a/src/lib/public/board/data/index.ts
+++ b/src/lib/public/board/data/index.ts
@@ -3,6 +3,8 @@ import OFFICERS_JSON from './officers.json';
 import TIERS_JSON from './tiers.json';
 import TEAMS_JSON from './teams.json';
 
+export { OFFICERS_JSON, TIERS_JSON, TEAMS_JSON };
+
 export const VISIBLE_TERMS = [Term.Fall22, Term.Spring22, Term.Fall21, Term.Spring21];
 
 export const TIERS = { ...TIERS_JSON };
@@ -15,7 +17,7 @@ export const TEAMS = [...TEAMS_JSON].reduce(
     tt[t.id] = t;
     return tt;
   },
-  {}
+  {} as Record<keyof typeof TEAMS_JSON[number], Team>
 );
 
 /** Pinned paths are featured on the landing page. */

--- a/src/lib/public/board/data/officers.json
+++ b/src/lib/public/board/data/officers.json
@@ -44,10 +44,6 @@
     "positions": { "F21": { "title": "Dev Officer", "tier": 19 } }
   },
   {
-    "fullName": "Your face here!",
-    "positions": { "F22": { "title": "Dev Officer", "tier": 19 } }
-  },
-  {
     "fullName": "Alan Cortez",
     "picture": "alan-cortez.webp",
     "socials": {

--- a/src/lib/public/board/data/officers.json
+++ b/src/lib/public/board/data/officers.json
@@ -44,6 +44,10 @@
     "positions": { "F21": { "title": "Dev Officer", "tier": 19 } }
   },
   {
+    "fullName": "Your face here!",
+    "positions": { "F22": { "title": "Dev Officer", "tier": 19 } }
+  },
+  {
     "fullName": "Alan Cortez",
     "picture": "alan-cortez.webp",
     "socials": {

--- a/src/lib/public/board/data/tiers.json
+++ b/src/lib/public/board/data/tiers.json
@@ -9,6 +9,7 @@
   "Special Events Officer": { "id": 7, "index": 450 },
   "Event Coordinator": { "id": 8, "index": 500 },
   "Marketing Leader": { "id": 9, "index": 550 },
+  "Marketing Officer": { "id": 24, "index": 560 },
   "Historian": { "id": 10, "index": 600 },
   "Algo Leader": { "id": 11, "index": 650 },
   "Algo Officer": { "id": 12, "index": 700 },
@@ -21,6 +22,8 @@
   "Dev Officer": { "id": 19, "index": 1050 },
   "AI Leader": { "id": 20, "index": 1100 },
   "AI Officer": { "id": 21, "index": 1150 },
+  "Game Dev Leader": { "id": 25, "index": 1170 },
+  "Game Dev Officer": { "id": 26, "index": 1180 },
   "Nodebuds Officer": { "id": 22, "index": 1200 },
   "ICC Representative": { "id": 23, "index": 1250 }
 }

--- a/src/lib/public/links/links.json
+++ b/src/lib/public/links/links.json
@@ -34,5 +34,6 @@
   "ai/projects/1": "https://docs.google.com/presentation/d/1BCYU3cTfNTffdUmiMHz8c2-A5qwna8yVPt7Fx3nzqGQ/edit?usp=sharing",
   "ai/projects/2": "https://colab.research.google.com/drive/1KaLN47LSfK4rAOzEOQleCX-Dy-qACZYC?usp=sharing",
   "roadmap": "https://github.com/users/EthanThatOneKid/projects/6",
-  "joblist": "/roadmap/views/10"
+  "joblist": "/roadmap/views/10",
+  "s23apply": "https://docs.google.com/forms/d/e/1FAIpQLScHHxO_LYHSyZvHozxuaSlhjY4WKU-lVsInm_cl_U88-6tbMQ/viewform"
 }

--- a/src/lib/server/links/data.ts
+++ b/src/lib/server/links/data.ts
@@ -18,4 +18,6 @@ export const LINKS = {
   'design-template':
     'https://www.figma.com/file/MED3kRKmIxcoKblNTveEZZ/acmDesign-Challenge-Sheet?node-id=0%3A1',
   'live-walk': 'https://www.figma.com/file/PtYSxzB8BbKh3L46dQSjf1/Live-Interaction?node-id=0%3A1',
+  s23apply:
+    'https://docs.google.com/forms/d/e/1FAIpQLScHHxO_LYHSyZvHozxuaSlhjY4WKU-lVsInm_cl_U88-6tbMQ/viewform',
 } as const;

--- a/src/routes/(site)/s23positions/+page.svelte
+++ b/src/routes/(site)/s23positions/+page.svelte
@@ -10,7 +10,7 @@
 
 <Spacing --min="175px" --med="200px" --max="200px" />
 
-<Block>
+<Block align={TextAlignment.LEFT}>
   <h1 slot="headline" class="size-lg">Spring 2023 board applications</h1>
   <p slot="text" class="size-sm">
     Listed below are the positions that are open for the Spring 2023 semester. Please read the
@@ -19,7 +19,7 @@
     position, you will be contacted by the current board member in charge of that position.
     <br />
     <br />
-    Last updated January 16th, 2023
+    Last updated January 18th, 2023
     <br />
     <br />
     <span class="apply-btn">

--- a/src/routes/(site)/s23positions/+page.svelte
+++ b/src/routes/(site)/s23positions/+page.svelte
@@ -1,0 +1,101 @@
+<script lang="ts">
+  import Block from '$lib/components/block/block.svelte';
+  import Spacing from '$lib/public/legacy/spacing.svelte';
+  import Button from '$lib/components/button/button.svelte';
+
+  import PositionList from './position-list.svelte';
+  import { POSITIONS } from './data';
+  import { TextAlignment } from '$lib/public/legacy/text-alignment';
+</script>
+
+<Spacing --min="175px" --med="200px" --max="200px" />
+
+<Block>
+  <h1 slot="headline" class="size-lg">Spring 2023 board applications</h1>
+  <p slot="text" class="size-sm">
+    Listed below are the positions that are open for the Spring 2023 semester. Please read the
+    descriptions carefully and apply for the position(s) that you are interested in. You may apply
+    for multiple positions, but you may only be selected for one. If you are selected for a
+    position, you will be contacted by the current board member in charge of that position.
+    <br />
+    <br />
+    Last updated January 16th, 2023
+    <br />
+    <br />
+    <span class="apply-btn">
+      <Button link="/s23apply" text="Apply now!" />
+    </span>
+  </p>
+</Block>
+
+<Spacing --min="175px" --med="200px" --max="200px" />
+
+<Block align={TextAlignment.LEFT}>
+  <h1 id="spring-2023-board-applications" slot="headline" class="size-lg">
+    Spring 2023 board applications
+  </h1>
+  <div slot="text" />
+</Block>
+
+<section class="positions-container">
+  <PositionList data={POSITIONS} />
+</section>
+
+<Spacing --med="64px" />
+
+<Block align={TextAlignment.LEFT}>
+  <h1 id="contact-information" slot="headline" class="size-lg">Contact information</h1>
+  <div slot="text" class="contact-text">
+    <p class="size-sm">
+      <span class="brand-italic"
+        >Feel free to contact the ACM Executive Board if you have questions.</span
+      >
+    </p>
+
+    <p class="size-sm">
+      <span class="brand-em">Karnikaa Velumani (ACM President)</span>
+    </p>
+    <ul>
+      <li>Email: <code>karnikaavelumani@csu.fullerton.edu</code></li>
+      <li>Discord: <code>Karbas#0001</code></li>
+    </ul>
+
+    <p>
+      <span class="brand-em">Ethan Davidson (ACM VP / Webmaster)</span>
+    </p>
+    <ul>
+      <li>Email: <code>ethandavidson@csu.fullerton.edu</code></li>
+      <li>Discord: <code>EthanThatOneKid#3456</code></li>
+    </ul>
+  </div>
+</Block>
+
+<Spacing --min="40px" --med="95px" --max="120px" />
+
+<style lang="scss">
+  .page-body {
+    width: 100%;
+    margin: 0 1rem;
+  }
+
+  .apply-btn {
+    display: flex;
+    justify-content: center;
+  }
+
+  .contact-text ul {
+    padding: 0 0 0 1rem;
+  }
+
+  .positions-container {
+    max-width: 100%;
+    margin: 0 auto;
+  }
+
+  @media (min-width: 768px) {
+    .positions-container {
+      max-width: 64ch;
+      margin: 0 1rem;
+    }
+  }
+</style>

--- a/src/routes/(site)/s23positions/+page.svelte
+++ b/src/routes/(site)/s23positions/+page.svelte
@@ -9,7 +9,7 @@
 
   function expandAll() {
     const positions = document.querySelectorAll('.position');
-    positions.forEach((el) => (el.setAttribute('open', 'true')));
+    positions.forEach((el) => el.setAttribute('open', 'true'));
   }
 </script>
 

--- a/src/routes/(site)/s23positions/+page.svelte
+++ b/src/routes/(site)/s23positions/+page.svelte
@@ -6,6 +6,11 @@
 
   import PositionList from './position-list.svelte';
   import { POSITIONS } from './data';
+
+  function expandAll() {
+    const positions = document.querySelectorAll('.position');
+    positions.forEach((el) => (el.setAttribute('open', 'true')));
+  }
 </script>
 
 <Spacing --min="175px" --med="200px" --max="200px" />
@@ -22,8 +27,8 @@
     Last updated January 18th, 2023
     <br />
     <br />
-    <span class="apply-btn">
-      <Button link="/s23apply" text="Apply now!" />
+    <span class="center-btn" on:click={expandAll} on:keypress={expandAll}>
+      <Button text="Expand all!" />
     </span>
   </p>
 </Block>
@@ -33,6 +38,12 @@
     <PositionList data={POSITIONS} />
   </div>
 </section>
+
+<Spacing --med="64px" />
+
+<span class="center-btn">
+  <Button link="/s23apply" text="Apply now!" />
+</span>
 
 <Spacing --med="64px" />
 
@@ -71,7 +82,7 @@
     margin: 0 1rem;
   }
 
-  .apply-btn {
+  .center-btn {
     display: flex;
     justify-content: center;
   }

--- a/src/routes/(site)/s23positions/+page.svelte
+++ b/src/routes/(site)/s23positions/+page.svelte
@@ -1,11 +1,11 @@
 <script lang="ts">
   import Block from '$lib/components/block/block.svelte';
-  import Spacing from '$lib/public/legacy/spacing.svelte';
   import Button from '$lib/components/button/button.svelte';
+  import Spacing from '$lib/public/legacy/spacing.svelte';
+  import { TextAlignment } from '$lib/public/legacy/text-alignment';
 
   import PositionList from './position-list.svelte';
   import { POSITIONS } from './data';
-  import { TextAlignment } from '$lib/public/legacy/text-alignment';
 </script>
 
 <Spacing --min="175px" --med="200px" --max="200px" />

--- a/src/routes/(site)/s23positions/+page.svelte
+++ b/src/routes/(site)/s23positions/+page.svelte
@@ -38,7 +38,9 @@
 </Block>
 
 <section class="positions-container">
-  <PositionList data={POSITIONS} />
+  <div class="positions-container-inner">
+    <PositionList data={POSITIONS} />
+  </div>
 </section>
 
 <Spacing --med="64px" />
@@ -88,12 +90,22 @@
   }
 
   .positions-container {
-    max-width: 100%;
-    margin: 0 auto;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+  }
+
+  .positions-container-inner {
+    margin: 0 24px;
+    width: 100%;
   }
 
   @media (min-width: 768px) {
     .positions-container {
+      margin-top: 2rem;
+    }
+
+    .positions-container-inner {
       max-width: 64ch;
       margin: 0 1rem;
     }

--- a/src/routes/(site)/s23positions/+page.svelte
+++ b/src/routes/(site)/s23positions/+page.svelte
@@ -28,15 +28,6 @@
   </p>
 </Block>
 
-<Spacing --min="175px" --med="200px" --max="200px" />
-
-<Block align={TextAlignment.LEFT}>
-  <h1 id="spring-2023-board-applications" slot="headline" class="size-lg">
-    Spring 2023 board applications
-  </h1>
-  <div slot="text" />
-</Block>
-
 <section class="positions-container">
   <div class="positions-container-inner">
     <PositionList data={POSITIONS} />

--- a/src/routes/(site)/s23positions/data.ts
+++ b/src/routes/(site)/s23positions/data.ts
@@ -1,5 +1,5 @@
-import type { ListItem } from '$lib/components/recursive-ul/types';
-import { TEAMS } from '$lib/public/board/data';
+import { li } from '$lib/components/recursive-ul/utils';
+
 import type { ClubPosition } from './position';
 
 /**
@@ -15,10 +15,6 @@ export const TOOLS = {
   'Social media': 'Discord, Instagram, LinkedIn, and YouTube',
   'Google Colab/Juptyer Notebook': 'Cloud development environment for Python',
 };
-
-function li(html: string, children?: ListItem[]): ListItem {
-  return { html, children };
-}
 
 export const POSITIONS: ClubPosition<keyof typeof TOOLS>[] = [
   {
@@ -59,7 +55,28 @@ export const POSITIONS: ClubPosition<keyof typeof TOOLS>[] = [
       li('Check Discord messages and respond to the important discussion in regards to Algo daily'),
     ],
   },
-  // TODO: Design Officer
+  {
+    title: 'Design Officer',
+    teamColor: 'var(--acm-design-rgb)',
+    requirements: [
+      li('Open mind to suggest new ideas in the field of design'),
+      li('Interest in learning and teaching common apps (ex. Figma)'),
+      li('Interest in programming to create basic front-end applications'),
+    ],
+    tools: ['Google Drive/Docs', 'Discord', 'Figma'],
+    responsibilities: [
+      li(
+        'Host engaging and interesting biweekly/weekly events along with the Design President and Officers'
+      ),
+      li(
+        'Research common design practices in tech and brands to relay this information via workshops and events, and to enhance our chapter'
+      ),
+      li('Attend weekly team meetings to catch up on what’s being worked on, progress, etc.'),
+      li(
+        'Check Discord messages and respond to the important discussion in regards to Design at least daily'
+      ),
+    ],
+  },
   {
     title: 'Dev Officer',
     teamColor: 'var(--acm-dev-rgb)',
@@ -88,6 +105,47 @@ export const POSITIONS: ClubPosition<keyof typeof TOOLS>[] = [
       ),
     ],
   },
-  // TODO: Game Dev Officer
-  // TODO: Marketing Officer
+  {
+    title: 'Game Dev Officer',
+    teamColor: 'var(--acm-foundry-rgb)',
+    requirements: [
+      li('Passion and interest in game development'),
+      li('Strong communication and leadership'),
+      li('Flexibility with skills to assist students in a variety of projects'),
+    ],
+    tools: ['Google Drive/Docs', 'Discord', 'GitHub'],
+    responsibilities: [
+      li(
+        'Attend Game Dev board meetings, provide essential input and collaborate with the Game Dev President and other officers'
+      ),
+      li('Assist and direct students in Game Dev related projects'),
+      li(
+        'Host engaging and interesting biweekly/weekly workshops along with the Design President and Officers'
+      ),
+      li(
+        'Research common game dev techniques to relay this information via workshops and events, and to enhance our chapter'
+      ),
+      li(
+        'Check Discord messages and respond to the important discussion in regards to Dev at least daily'
+      ),
+    ],
+  },
+  {
+    title: 'Marketing Officer',
+    teamColor: 'var(--acm-marketing-rgb)',
+    requirements: [
+      li('Interest in exploring business and marketing'),
+      li('Substantial awareness or usage of multiple social media platforms'),
+      li('Represent and advocate diversity within the club'),
+    ],
+    tools: ['Google Drive/Docs', 'Discord', 'GitHub'],
+    responsibilities: [
+      li(
+        'Assist in designing flyers for marketing to be printed and posted on all forms of social media'
+      ),
+      li('Suggest and direct new ideas for the diversification of our club '),
+      li('Take pictures of our members to add to our socials and website gallery'),
+      li('Produce paragraphs for the announcements in our official Discord server'),
+    ],
+  },
 ];

--- a/src/routes/(site)/s23positions/data.ts
+++ b/src/routes/(site)/s23positions/data.ts
@@ -1,0 +1,93 @@
+import type { ListItem } from '$lib/components/recursive-ul/types';
+import { TEAMS } from '$lib/public/board/data';
+import type { ClubPosition } from './position';
+
+/**
+ * The tools that are used in the club.
+ *
+ * @remarks This is a map of tool names to their reasons for being used.
+ */
+export const TOOLS = {
+  'Google Drive/Docs': 'To collaborate on presentations, documents, and spreadsheets.',
+  Discord: 'Internal team communication, assistance for student questions',
+  Figma: 'Create marketing materials and teaching students how to use it',
+  GitHub: 'To collaborate on code, manage projects, and teach students how to use it',
+  'Social media': 'Discord, Instagram, LinkedIn, and YouTube',
+  'Google Colab/Juptyer Notebook': 'Cloud development environment for Python',
+};
+
+function li(html: string, children?: ListItem[]): ListItem {
+  return { html, children };
+}
+
+export const POSITIONS: ClubPosition<keyof typeof TOOLS>[] = [
+  {
+    title: 'AI Officer',
+    teamColor: 'var(--acm-ai-rgb)',
+    requirements: [
+      li('Interest in artificial intelligence'),
+      li('Interest in public speaking/leading events'),
+      li('Passion for guiding AI related student projects'),
+    ],
+    tools: ['Google Drive/Docs', 'Discord', 'Google Colab/Juptyer Notebook'],
+    responsibilities: [
+      li('Attend AI board meetings and collaborate with other AI board members for workshops'),
+      li(
+        'Create biweekly/weekly workshop presentations prior to events that effectively teach students algorithms/data structures',
+        [li('Suggest new ideas/topics to teach at a workshop')]
+      ),
+      li('Oversee multiple AI semester projects'),
+      li('Check Discord messages and respond to the important discussion in regards to AI daily'),
+    ],
+  },
+  {
+    title: 'Algo Officer',
+    teamColor: 'var(--acm-algo-rgb)',
+    requirements: [
+      li('Passion for algorithms'),
+      li('Productive time management'),
+      li('Interest in public speaking and leading events'),
+    ],
+    tools: ['Google Drive/Docs', 'Discord'],
+    responsibilities: [
+      li(
+        'Attend Algo board meetings and collaborate with other Algo board members for Algo workshops'
+      ),
+      li(
+        'Create weekly workshop presentations prior to events that effectively teach students algorithms/data structures'
+      ),
+      li('Check Discord messages and respond to the important discussion in regards to Algo daily'),
+    ],
+  },
+  // TODO: Design Officer
+  {
+    title: 'Dev Officer',
+    teamColor: 'var(--acm-dev-rgb)',
+    requirements: [
+      li('Passion for helping students develop projects'),
+      li('Strong communication and leadership'),
+      li('Flexibility with skills to assist students in a variety of projects'),
+    ],
+    tools: ['Google Drive/Docs', 'Discord', 'GitHub'],
+    responsibilities: [
+      li(
+        'Attend Dev board meetings, provide essential input and collaborate with the Dev President and other officers'
+      ),
+      li('Oversee multiple Dev semester projects'),
+      li('Assist and direct students in ACM Open Source Projects'),
+      li(
+        'Possibility of being tasked to collaborate and participate in events created in partnerships with other ACM branches',
+        [
+          li(
+            'These can include creating and presenting workshops on behalf of Dev or organizing an collab event'
+          ),
+        ]
+      ),
+      li(
+        'Check Discord messages and respond to the important discussion in regards to Dev at least daily'
+      ),
+    ],
+  },
+  // TODO: Game Dev Officer
+  // TODO: Marketing Officer
+];

--- a/src/routes/(site)/s23positions/page.test.ts
+++ b/src/routes/(site)/s23positions/page.test.ts
@@ -1,0 +1,8 @@
+import { expect, test } from '@playwright/test';
+
+test.describe.configure({ mode: 'parallel' });
+
+test('s23positions page has expected h1', async ({ page }) => {
+  await page.goto('/s23positions');
+  expect(await page.textContent('h1')).toBe('Spring 2023 board applications');
+});

--- a/src/routes/(site)/s23positions/position-list.svelte
+++ b/src/routes/(site)/s23positions/position-list.svelte
@@ -1,0 +1,15 @@
+<script lang="ts">
+  import Position from './position.svelte';
+  import type { ClubPosition } from './position';
+  import type { TOOLS } from './data';
+
+  export let data: ClubPosition<keyof typeof TOOLS>[];
+</script>
+
+{#each data as position}
+  <section class="position">
+    <Position data={position} />
+  </section>
+{:else}
+  <p>There are no open positions at this time.</p>
+{/each}

--- a/src/routes/(site)/s23positions/position-list.svelte
+++ b/src/routes/(site)/s23positions/position-list.svelte
@@ -7,9 +7,7 @@
 </script>
 
 {#each data as position}
-  <section class="position">
-    <Position data={position} />
-  </section>
+  <Position data={position} />
 {:else}
   <p>There are no open positions at this time.</p>
 {/each}

--- a/src/routes/(site)/s23positions/position.svelte
+++ b/src/routes/(site)/s23positions/position.svelte
@@ -71,7 +71,7 @@
       justify-content: space-between;
       padding: 1rem;
       cursor: pointer;
-      
+
       /**
        * [START HACK] Remove the default marker from the <details> element.
        * @see https://stackoverflow.com/a/66814239

--- a/src/routes/(site)/s23positions/position.svelte
+++ b/src/routes/(site)/s23positions/position.svelte
@@ -1,0 +1,100 @@
+<script lang="ts">
+  import RecursiveUL from '$lib/components/recursive-ul/recursive-ul.svelte';
+  import type { ClubPosition } from './position';
+  import { TOOLS } from './data';
+
+  export let data: ClubPosition<keyof typeof TOOLS>;
+
+  const id = data.title.replaceAll(/\s/g, '-').toLowerCase();
+  const formattedTools = data.tools.map((name) => ({
+    html: `<span class="headers">${name}:</span> ${TOOLS[name]}`,
+  }));
+</script>
+
+<details {id} style:--highlights={data.teamColor} class="position">
+  <summary class="position__summary">
+    <h2 class="headers">{data.title}</h2>
+  </summary>
+
+  <div class="position__body">
+    <div class="position__requirements">
+      <h3 class="headers">What you need</h3>
+      <RecursiveUL data={data.requirements} />
+    </div>
+
+    <p class="position__tools">
+      <span class="headers position__tools__title">Tools:</span>
+      <span class="position__tools__text"
+        >We used following tools to plan and keep up with the workload</span
+      >
+      <RecursiveUL data={formattedTools} />
+    </p>
+
+    <div class="position__responsibilities">
+      <h3 class="headers">Responsibilities</h3>
+      <RecursiveUL data={data.responsibilities} />
+    </div>
+  </div>
+</details>
+
+<style lang="scss">
+  .position {
+    scroll-padding-top: 1rem;
+    margin: 1rem 0;
+    box-shadow: 0 6px 18px rgba(var(--highlights, --acm-general-rgb), 0.25);
+    transition: all 0.15s ease-in-out;
+    border-radius: 30px;
+    border: 2px solid var(--acm-dark);
+
+    & :global(ul) {
+      padding-left: 1.5rem;
+      margin-left: 0;
+    }
+
+    &:hover {
+      box-shadow: 0 6px 18px rgba(var(--highlights, --acm-general-rgb), 0.65);
+    }
+
+    &[open] {
+      box-shadow: 0 6px 24px rgba(var(--highlights, --acm-general-rgb), 0.75);
+      border: 2px solid rgb(var(--highlights, --acm-general-rgb));
+    }
+
+    &:hover h2,
+    &[open] h2 {
+      color: rgb(var(--highlights, --acm-general-rgb));
+    }
+
+    &__summary {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 1rem;
+      cursor: pointer;
+    }
+
+    &__body {
+      padding: 1rem;
+    }
+
+    &__requirements {
+      margin-bottom: 1rem;
+    }
+
+    &__tools {
+      margin-bottom: 1rem;
+
+      &__title {
+        margin-bottom: 1rem;
+      }
+
+      &__text {
+        margin-bottom: 0.5rem;
+      }
+    }
+
+    &__responsibilities {
+      margin-bottom: 1rem;
+    }
+  }
+</style>

--- a/src/routes/(site)/s23positions/position.svelte
+++ b/src/routes/(site)/s23positions/position.svelte
@@ -71,6 +71,18 @@
       justify-content: space-between;
       padding: 1rem;
       cursor: pointer;
+      
+      /**
+       * [START HACK] Remove the default marker from the <details> element.
+       * @see https://stackoverflow.com/a/66814239
+       * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/details#customizing_the_disclosure_widget
+       */
+      list-style: none;
+      &::marker, /* Latest Chrome, Edge, Firefox */ 
+      &::-webkit-details-marker /* Safari */ {
+        display: none;
+      }
+      /* [END HACK] */
     }
 
     &__body {

--- a/src/routes/(site)/s23positions/position.ts
+++ b/src/routes/(site)/s23positions/position.ts
@@ -1,0 +1,10 @@
+import type { ListItem } from '$lib/components/recursive-ul/types';
+import type { TIERS } from '$lib/public/board/data';
+
+export interface ClubPosition<ToolNames extends string = string> {
+  title: keyof typeof TIERS;
+  teamColor: string;
+  requirements: ListItem[];
+  tools: ToolNames[];
+  responsibilities: ListItem[];
+}

--- a/static/global.css
+++ b/static/global.css
@@ -64,6 +64,10 @@ body:has(nav > input[type='checkbox']:checked) {
   font-weight: 700;
 }
 
+.brand-italic {
+  font-style: italic;
+}
+
 .brand-header,
 .headers {
   font-weight: 600;

--- a/static/global.css
+++ b/static/global.css
@@ -19,6 +19,8 @@
   --acm-algo-rgb: 157, 53, 231;
   --acm-design-rgb: 255, 67, 101;
   --acm-dev-rgb: 30, 108, 255;
+  --acm-foundry-rgb: 111, 22, 255;
+  --acm-marketing-rgb: 212, 17, 83;
   --acm-special-events-rgb: 255, 208, 41;
 
   --perma-light: #f8f8f8;


### PR DESCRIPTION
### `/s23positions`

This PR creates a new page for board applications, as per the request in #750. The page can be found at https://acmcsuf.com/s23positions.

The form for students to apply can be accessed via the following link: https://acmcsuf.com/s23apply

The button on the page links to the form for students to apply.

The content for the page, including information about each application, has been copied and pasted from the following Google Doc: https://docs.google.com/document/d/1jTtr2UUEJsRsz0AOQPTe_f0lDk89BK_tfiw590o_U_s/edit#heading=h.yqghk8npo2et

The page design can be viewed at the following Figma link: https://www.figma.com/file/25dCY91gyAqADj3aB9xgfl/Board-Apps?node-id=0%3A1&t=WA866jRB4hQrFrrN-0

### Changelog

- New page endpoint `/s23positions`
- Add "Marketing Officer", "Game Dev Leader", and "Game Dev Officer" to `src/lib/public/board/data/tiers.json`
- Add `--acm-foundry-rgb`, `--acm-marketing-rgb`, and `.brand-italic` to `static/global.css`

Resolves #750