### PR TITLE
Fix Genuary workflow

### DIFF
--- a/.github/workflows/update_genuary.yaml
+++ b/.github/workflows/update_genuary.yaml
@@ -13,15 +13,18 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - run: |
+      - name: Get pins
+        run: |
           go run github.com/ethanthatonekid/pins@latest \
             get -o /tmp/pins $GUILD_ID "channel_parent_id == $CHANNEL_ID"
+          go run github.com/ethanthatonekid/pins@latest get -o /tmp/pins 710225099923521558 "channel_parent_id == 1055675648296890388"
         env:
           GUILD_ID: ${{ secrets.GUILD_ID }}
           CHANNEL_ID: ${{ secrets.GENUARY_CHANNEL_ID }}
           DISCORD_TOKEN: ${{ secrets.GENUARY_DISCORD_TOKEN }}
 
-      - id: transform-genuary
+      - name: Transform Genuary data
+        id: transform-genuary
         run: |
           year=$(date +%Y)
           echo "year=$year" >> $GITHUB_OUTPUT
@@ -35,7 +38,8 @@ jobs:
             echo "updated=1" >> $GITHUB_OUTPUT
           fi
 
-      - if: steps.transform-genuary.outputs.updated == 1
+      - name: Create pull request
+        if: steps.transform-genuary.outputs.updated == 1
         uses: peter-evans/create-pull-request@v4
         with:
           title: |-

--- a/scripts/transform-genuary.js
+++ b/scripts/transform-genuary.js
@@ -12,6 +12,10 @@ async function main() {
     }
 
     const attachment = pin.attachments[0];
+    if (!attachment) {
+      continue;
+    }
+
     const src = attachment.proxy_url || null;
     const alt = content.channel_names[pin.channel_id] || '';
     if (!/^(\d+) /.test(alt)) {


### PR DESCRIPTION
### What happened?

How embarrassing; my production workflow [failed to run](https://github.com/EthanThatOneKid/acmcsuf.com/actions/runs/4126636847/jobs/7128823924#step:4:21)!

### Resolution

I added a few lines of code to resolve the error that was printed.

<https://github.com/EthanThatOneKid/acmcsuf.com/blob/4604425460d37c26c36fe3adece861b9776c749b/scripts/transform-genuary.js#L15-L17>

I also took it upon myself to add names to each of the steps of the `.github/workflows/update_genuary.yaml` workflow.

