### PR TITLE
Make unique `TextAlignment` enum

### DIFF
--- a/src/lib/public/legacy/text-alignment.ts
+++ b/src/lib/public/legacy/text-alignment.ts
@@ -1,5 +1,0 @@
-export enum TextAlignment {
-  CENTER = 'center',
-  LEFT = 'left',
-  RIGHT = 'right',
-}

--- a/src/routes/(site)/genuary/genuary-page.svelte
+++ b/src/routes/(site)/genuary/genuary-page.svelte
@@ -2,7 +2,7 @@
   import ReadyUp from '../ready-up.svelte';
   import Block from '$lib/components/block/block.svelte';
   import Spacing from '$lib/public/legacy/spacing.svelte';
-  import { TextAlignment } from '$lib/public/legacy/text-alignment';
+  import { TextAlignment } from '$lib/public/text-alignment/text-alignment';
   import Collage from './collage.svelte';
   import type { CollagePiece } from './collage';
 

--- a/src/routes/(site)/s23positions/+page.svelte
+++ b/src/routes/(site)/s23positions/+page.svelte
@@ -3,7 +3,7 @@
   import Block from '$lib/components/block/block.svelte';
   import Button from '$lib/components/button/button.svelte';
   import Spacing from '$lib/public/legacy/spacing.svelte';
-  import { TextAlignment } from '$lib/public/legacy/text-alignment';
+  import { TextAlignment } from '$lib/public/text-alignment/text-alignment';
 
   import PositionList from './position-list.svelte';
   import { POSITIONS } from './data';


### PR DESCRIPTION
Removes a duplicate enum `TextAlignment`, asserting that the only instance of a `TextAlignment` enum in this repository is the one defined in `src/lib/public/text-alignment/text-alignment.ts`.

Resolves #582.