### PR TITLE
Remove `preventDefault` from anchor navigation

### DIFF
--- a/src/lib/components/nav/bar.svelte
+++ b/src/lib/components/nav/bar.svelte
@@ -17,9 +17,7 @@
   let checkbox: HTMLInputElement;
 
   function handleClose(ev: Event) {
-    ev.preventDefault();
     ev.stopPropagation();
-
     if (checkbox.checked) {
       checkbox.checked = false;
     }


### PR DESCRIPTION
I won't lie, I accidentally put `preventDefault` on the links in the navbar.