### PR TITLE
Fix error visual in acmcsuf.com/quiz

### DIFF
--- a/src/routes/(site)/quiz/quiz.svelte
+++ b/src/routes/(site)/quiz/quiz.svelte
@@ -114,7 +114,7 @@
         on:click={goRight}
         disabled={index === data.questions.length - 1 || !(responses ?? [])[index]}
         class:disable-arrow={index === data.questions.length - 1 || !(responses ?? [])[index]}
-        class="arrow"><BwIcon src="/assets/svg/arrow-left.svg" alt="left arrow" /></button
+        class="arrow"><BwIcon src="/assets/svg/arrow-right.svg" alt="right arrow" /></button
       >
     </div>
     <button
@@ -128,7 +128,7 @@
   {:else if showMoreInfo}
     <MoreInfo {...showTeam} />
     <button on:click={goBackToResults} class="arrow return-to-results"
-      ><BwIcon src="/assets/svg/arrow-left.svg" alt="left arrow" />
+      ><BwIcon src="/assets/svg/arrow-right.svg" alt="right arrow" />
       <h3>Check out other teams</h3></button
     >
     <!-- DISPLAY THE RESULTS -->
@@ -181,7 +181,7 @@
       <p class="italic">This will wipe your current results</p>
     </button>
     <button class="arrow action-btn" on:click={() => showTeamDetails(TEAMS.general)}>
-      >Want to help out ACM?</button
+      Want to help out ACM?</button
     >
     <p class="italic fine-text">
       Take these results with a grain of salt. This is meant to be a fun little quiz and you are


### PR DESCRIPTION
This is my work about the issue #734 and here is the result 

#Result : 
  - No more 2 button left like in the beginning
<img width="488" alt="Screenshot 2023-02-21 at 23 20 38" src="https://user-images.githubusercontent.com/99657702/220627469-dc45b8ee-1c51-4430-8bc0-2e5a16cc3181.png">
 - Efface an extra ">" in from of the "want to help" button extra symbol
<img width="283" alt="Screenshot 2023-02-21 at 23 21 09" src="https://user-images.githubusercontent.com/99657702/220627785-0c3a0a7c-359e-46e0-b4af-093cef915264.png">
