### PR TITLE
Add webkit to fix dark mode navbar blur in safari

### DIFF
--- a/src/lib/components/nav/bar.svelte
+++ b/src/lib/components/nav/bar.svelte
@@ -103,6 +103,7 @@
       background-color: var(--navbar-bg);
       box-shadow: var(--nav-shadow);
       z-index: -1;
+      -webkit-backdrop-filter: blur(10px);
       backdrop-filter: blur(10px);
     }
 


### PR DESCRIPTION
Fixes #682.