### PR TITLE
Genuary Transform: Remove line break from end of JSON file

### DIFF
--- a/scripts/transform-genuary/get-media-from-pins.js
+++ b/scripts/transform-genuary/get-media-from-pins.js
@@ -4,7 +4,7 @@ const ALLOWED_MEDIA_DOMAINS = ['cdn.discordapp.com', 'i.imgur.com'];
  * @param {object} mediaIn Media data
  */
 export function serializeMedia(mediaIn) {
-  return JSON.stringify(mediaIn, null, 2) + '\n';
+  return JSON.stringify(mediaIn, null, 2);
 }
 
 /**


### PR DESCRIPTION
After generating the JSON data, a slight formatting error is found related to the new line placed at the end of the file.

<img width="546" alt="image" src="https://user-images.githubusercontent.com/31261035/228687237-d4755a91-79e4-4018-a5e5-ddbfa66d00c5.png">

### Related

- https://github.com/EthanThatOneKid/acmcsuf.com/pull/824
- https://github.com/EthanThatOneKid/acmcsuf.com/pull/821