### PR TITLE
Add support for ics.acmcsuf.com

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@js-temporal/polyfill": "^0.4.4",
         "cropperjs": "^1.5.13",
         "html-to-text": "^9.0.5",
+        "node-ical": "^0.16.1",
         "pomo": "github:ethanthatonekid/pomo#npm",
         "qrcode": "^1.5.3",
         "rrule": "^2.7.2",
@@ -1266,6 +1267,21 @@
         "node": "*"
       }
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+    },
+    "node_modules/axios": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.4.0.tgz",
+      "integrity": "sha512-S4XCWMEmzvo64T9GfvQDOXgYRDJ/wsSZc7Jvdgx5u1sd0JwsuPLqb3SYmusag+edF6ziyMensPVqLTSc1PiSEA==",
+      "dependencies": {
+        "follow-redirects": "^1.15.0",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
     "node_modules/axobject-query": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-3.2.1.tgz",
@@ -1531,6 +1547,17 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -1637,6 +1664,14 @@
       "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/dequal": {
@@ -2201,6 +2236,38 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.7.tgz",
       "integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==",
       "dev": true
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
+      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
     },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
@@ -2827,6 +2894,15 @@
         "node": ">=10"
       }
     },
+    "node_modules/luxon": {
+      "version": "1.28.1",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-1.28.1.tgz",
+      "integrity": "sha512-gYHAa180mKrNIUJCbwpmD0aTu9kV0dREDrwNnuyFAsO1Wt0EVYSZelPnJlbj9HplzXX/YWXHFTL45kvZ53M0pw==",
+      "optional": true,
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.1",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.1.tgz",
@@ -2950,6 +3026,25 @@
         "ufo": "^1.1.2"
       }
     },
+    "node_modules/moment": {
+      "version": "2.29.4",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
+      "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/moment-timezone": {
+      "version": "0.5.43",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.43.tgz",
+      "integrity": "sha512-72j3aNyuIsDxdF1i7CEgV2FfxM1r6aaqJyLB2vwb33mXYyoyLly+F1zbWqhA3/bVIoJ4szlUoMbUnVdid32NUQ==",
+      "dependencies": {
+        "moment": "^2.29.4"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/mri": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
@@ -3038,6 +3133,33 @@
       "engines": {
         "node": ">= 6.13.0"
       }
+    },
+    "node_modules/node-ical": {
+      "version": "0.16.1",
+      "resolved": "https://registry.npmjs.org/node-ical/-/node-ical-0.16.1.tgz",
+      "integrity": "sha512-AAlJbvyRlQ5QT3LtYAvveY/gZlvHAIjHR/suQp1YVX/RySCxI/qZcyauRDKv2QSH0zNG0J8iv5T1gv6FadoETA==",
+      "dependencies": {
+        "axios": "1.4.0",
+        "moment-timezone": "^0.5.31",
+        "rrule": "2.6.4",
+        "uuid": "^9.0.0"
+      }
+    },
+    "node_modules/node-ical/node_modules/rrule": {
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/rrule/-/rrule-2.6.4.tgz",
+      "integrity": "sha512-sLdnh4lmjUqq8liFiOUXD5kWp/FcnbDLPwq5YAc/RrN6120XOPb86Ae5zxF7ttBVq8O3LxjjORMEit1baluahA==",
+      "dependencies": {
+        "tslib": "^1.10.0"
+      },
+      "optionalDependencies": {
+        "luxon": "^1.21.3"
+      }
+    },
+    "node_modules/node-ical/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",
@@ -3433,6 +3555,11 @@
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "node_modules/punycode": {
       "version": "2.3.0",
@@ -5432,6 +5559,21 @@
       "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
       "dev": true
     },
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+    },
+    "axios": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.4.0.tgz",
+      "integrity": "sha512-S4XCWMEmzvo64T9GfvQDOXgYRDJ/wsSZc7Jvdgx5u1sd0JwsuPLqb3SYmusag+edF6ziyMensPVqLTSc1PiSEA==",
+      "requires": {
+        "follow-redirects": "^1.15.0",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
     "axobject-query": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-3.2.1.tgz",
@@ -5626,6 +5768,14 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
+    "combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "requires": {
+        "delayed-stream": "~1.0.0"
+      }
+    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -5701,6 +5851,11 @@
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
       "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A=="
+    },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="
     },
     "dequal": {
       "version": "2.0.3",
@@ -6128,6 +6283,21 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.7.tgz",
       "integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==",
       "dev": true
+    },
+    "follow-redirects": {
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
+      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA=="
+    },
+    "form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "requires": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      }
     },
     "fs.realpath": {
       "version": "1.0.0",
@@ -6595,6 +6765,12 @@
         "yallist": "^4.0.0"
       }
     },
+    "luxon": {
+      "version": "1.28.1",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-1.28.1.tgz",
+      "integrity": "sha512-gYHAa180mKrNIUJCbwpmD0aTu9kV0dREDrwNnuyFAsO1Wt0EVYSZelPnJlbj9HplzXX/YWXHFTL45kvZ53M0pw==",
+      "optional": true
+    },
     "magic-string": {
       "version": "0.30.1",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.1.tgz",
@@ -6685,6 +6861,19 @@
         "ufo": "^1.1.2"
       }
     },
+    "moment": {
+      "version": "2.29.4",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
+      "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w=="
+    },
+    "moment-timezone": {
+      "version": "0.5.43",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.43.tgz",
+      "integrity": "sha512-72j3aNyuIsDxdF1i7CEgV2FfxM1r6aaqJyLB2vwb33mXYyoyLly+F1zbWqhA3/bVIoJ4szlUoMbUnVdid32NUQ==",
+      "requires": {
+        "moment": "^2.29.4"
+      }
+    },
     "mri": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
@@ -6741,6 +6930,33 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz",
       "integrity": "sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA=="
+    },
+    "node-ical": {
+      "version": "0.16.1",
+      "resolved": "https://registry.npmjs.org/node-ical/-/node-ical-0.16.1.tgz",
+      "integrity": "sha512-AAlJbvyRlQ5QT3LtYAvveY/gZlvHAIjHR/suQp1YVX/RySCxI/qZcyauRDKv2QSH0zNG0J8iv5T1gv6FadoETA==",
+      "requires": {
+        "axios": "1.4.0",
+        "moment-timezone": "^0.5.31",
+        "rrule": "2.6.4",
+        "uuid": "^9.0.0"
+      },
+      "dependencies": {
+        "rrule": {
+          "version": "2.6.4",
+          "resolved": "https://registry.npmjs.org/rrule/-/rrule-2.6.4.tgz",
+          "integrity": "sha512-sLdnh4lmjUqq8liFiOUXD5kWp/FcnbDLPwq5YAc/RrN6120XOPb86Ae5zxF7ttBVq8O3LxjjORMEit1baluahA==",
+          "requires": {
+            "luxon": "^1.21.3",
+            "tslib": "^1.10.0"
+          }
+        },
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
     },
     "normalize-path": {
       "version": "3.0.0",
@@ -6987,6 +7203,11 @@
           "dev": true
         }
       }
+    },
+    "proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "punycode": {
       "version": "2.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,6 +41,7 @@
         "svelte-check": "^3.4.3",
         "tslib": "^2.4.1",
         "typescript": "^5.0.0",
+        "typescript-language-server": "^3.3.2",
         "vite": "^4.3.6",
         "vitest": "^0.32.2"
       }
@@ -4256,6 +4257,18 @@
         "node": ">=14.17"
       }
     },
+    "node_modules/typescript-language-server": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/typescript-language-server/-/typescript-language-server-3.3.2.tgz",
+      "integrity": "sha512-jzun53CIkTbpAki0nP+hk5baGW+86SNNlVhyIj2ZUy45zUkCnmoetWuAtfRRQYrlIr8x4QB3ymGJPuwDQSd/ew==",
+      "dev": true,
+      "bin": {
+        "typescript-language-server": "lib/cli.mjs"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
     "node_modules/ufo": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.1.2.tgz",
@@ -7519,6 +7532,12 @@
       "version": "5.1.6",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
       "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA=="
+    },
+    "typescript-language-server": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/typescript-language-server/-/typescript-language-server-3.3.2.tgz",
+      "integrity": "sha512-jzun53CIkTbpAki0nP+hk5baGW+86SNNlVhyIj2ZUy45zUkCnmoetWuAtfRRQYrlIr8x4QB3ymGJPuwDQSd/ew==",
+      "dev": true
     },
     "ufo": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "@js-temporal/polyfill": "^0.4.4",
     "cropperjs": "^1.5.13",
     "html-to-text": "^9.0.5",
+    "node-ical": "^0.16.1",
     "pomo": "github:ethanthatonekid/pomo#npm",
     "qrcode": "^1.5.3",
     "rrule": "^2.7.2",

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "svelte-check": "^3.4.3",
     "tslib": "^2.4.1",
     "typescript": "^5.0.0",
+    "typescript-language-server": "^3.3.2",
     "vite": "^4.3.6",
     "vitest": "^0.32.2"
   },

--- a/src/lib/server/events/data/known-ics.ts
+++ b/src/lib/server/events/data/known-ics.ts
@@ -1,0 +1,2 @@
+const knownICS = ['https://ics.acmcsuf.com/guilds/710225099923521558/events.ics'];
+export default knownICS;

--- a/src/lib/server/events/gcal.test.ts
+++ b/src/lib/server/events/gcal.test.ts
@@ -7,7 +7,7 @@ import CLUB_EVENTS from './data/club-events.json?raw';
 
 test('transforms GCalEvent list to ClubEvent list', async () => {
   const input = JSON.parse(GCAL_EVENTS) as GCalEvent[];
-  const actual = fromGCal(input);
+  const actual = fromGCal(input, 'America/Los_Angeles');
 
   // To generate 'src/lib/server/events/data/club-events.json', uncomment the
   // following lines of code then run 'npm t' (and 'npm run all'):

--- a/src/lib/server/events/gcal.ts
+++ b/src/lib/server/events/gcal.ts
@@ -4,9 +4,9 @@ import { calendar } from '@googleapis/calendar';
 import { makeClubEvent } from './event';
 import { GCAL_API_KEY, GCAL_ID } from '$lib/server/env';
 
-export function fromGCal(events: GCalEvent[]): ClubEvent[] {
+export function fromGCal(events: GCalEvent[], timezone: string): ClubEvent[] {
   const sortedEvents: ClubEvent[] = [];
-  const refDate = Temporal.Now.zonedDateTimeISO('America/Los_Angeles');
+  const refDate = Temporal.Now.zonedDateTimeISO(timezone);
 
   for (const event of events) {
     const clubEvent = makeClubEvent(event, refDate);

--- a/src/lib/server/events/ical.ts
+++ b/src/lib/server/events/ical.ts
@@ -1,0 +1,143 @@
+import { TEAMS } from '$lib/public/board/data';
+import { Temporal } from '@js-temporal/polyfill';
+import * as ical from 'node-ical';
+import knownICS from './data/known-ics';
+import type { Team } from '$lib/public/board/types';
+import type { ClubEvent } from '$lib/public/events/event';
+
+import {
+  parseLocation,
+  makeEventLink,
+  produceSummary,
+  makeGoogleCalendarLink,
+  makeOutlookCalendarLink,
+} from './event';
+
+async function downloadOneICS(url: string) {
+  const ics = await fetch(url).then((res) => res.text());
+  return ical.sync.parseICS(ics);
+}
+
+// Download and parse the ICS files from the given URLs. All events are merged
+// into a single calendar.
+export async function downloadICS(urls: string[]): Promise<ical.CalendarResponse> {
+  const icses = await Promise.all(urls.map(downloadOneICS));
+  const calendar: ical.CalendarResponse = {};
+  for (const ics of icses) {
+    Object.assign(calendar, ics);
+  }
+  return calendar;
+}
+
+// Download and parse the ICS files from the known URLs. All events are merged
+// into a single calendar.
+export async function downloadKnownICS(): Promise<ical.CalendarResponse> {
+  return downloadICS(knownICS);
+}
+
+export type ExtendedClubEvent = ClubEvent & {
+  dtStart: Temporal.ZonedDateTime;
+  dtEnd: Temporal.ZonedDateTime;
+};
+
+export function fromICal(calendar: ical.CalendarResponse, timezone: string): ClubEvent[] {
+  const events: ExtendedClubEvent[] = [];
+  const refDate = Temporal.Now.zonedDateTimeISO(timezone);
+  for (const uid in calendar) {
+    const event = calendar[uid];
+    if (event.type != 'VEVENT') {
+      continue;
+    }
+    const clubEvent = makeClubEvent(uid, event, refDate);
+    if (clubEvent) {
+      events.push(clubEvent);
+    }
+  }
+  events.sort((a, b) => Temporal.ZonedDateTime.compare(a.dtStart, b.dtStart));
+  return events;
+}
+
+function toTemporalDateTime(date: ical.DateWithTimeZone): Temporal.ZonedDateTime {
+  return Temporal.Instant.fromEpochMilliseconds(date.getTime()).toZonedDateTimeISO(date.tz);
+}
+
+function makeClubEvent(
+  uid: string,
+  event: ical.VEvent,
+  refDate: Temporal.ZonedDateTime
+): ExtendedClubEvent | null {
+  console.log('evnet starts at', event.start, event.summary);
+
+  const tz = refDate.getTimeZone();
+  const dtStart = toTemporalDateTime(event.start).withTimeZone(tz);
+  const dtEnd = toTemporalDateTime(event.end).withTimeZone(tz);
+
+  const date = dtStart.toString();
+  const month = dtStart.toLocaleString('en-US', { month: 'long' });
+  const day = dtStart.day;
+
+  const startTime = dtStart
+    .toLocaleString('en-US', { hour: 'numeric', minute: 'numeric' })
+    .replace(' ', ' ');
+  const endTime = dtEnd
+    .toLocaleString('en-US', { hour: 'numeric', minute: 'numeric' })
+    .replace(' ', ' ');
+
+  const hasStarted = Temporal.ZonedDateTime.compare(refDate, dtStart) >= 0;
+  const hasEnded = Temporal.ZonedDateTime.compare(refDate, dtEnd) >= 0;
+
+  const { location, meetingLink } = parseLocation(event.location);
+  const title = event.summary ?? 'TBD';
+  const description = event.description ?? '';
+  const id = 'ical-' + uid;
+  const selfLink = makeEventLink(id);
+  const recurring = false; // currently unsupported by Discord
+  const summary = produceSummary(title, description, selfLink);
+  const team = guessTeam(summary);
+
+  const makeCalendarArgs = [title, summary, location, dtStart, dtEnd] as const;
+  const calendarLinks = {
+    google: makeGoogleCalendarLink(...makeCalendarArgs).toString(),
+    outlook: makeOutlookCalendarLink(...makeCalendarArgs).toString(),
+  };
+
+  return {
+    month,
+    day,
+    dtStart,
+    dtEnd,
+    startTime,
+    endTime,
+    hasStarted,
+    hasEnded,
+    date,
+    location,
+    title,
+    description,
+    summary,
+    meetingLink,
+    id,
+    selfLink,
+    recurring,
+    team,
+    calendarLinks,
+  };
+}
+
+const prefixMap = {
+  AI: TEAMS.ai,
+  Algo: TEAMS.algo,
+  Design: TEAMS.design,
+  Dev: TEAMS.dev,
+  ICPC: TEAMS.icpc,
+  'Game Dev': TEAMS.gamedev,
+};
+
+function guessTeam(summary: string): Team {
+  for (const [prefix, team] of Object.entries(prefixMap)) {
+    if (summary.startsWith(prefix + ' ')) {
+      return team;
+    }
+  }
+  return TEAMS.general;
+}

--- a/src/routes/(site)/events/[query].json/+server.ts
+++ b/src/routes/(site)/events/[query].json/+server.ts
@@ -3,6 +3,7 @@ import type { RouteParams } from './$types';
 import { DEBUG_FLAG_ENABLED } from '$lib/server/flags';
 import { SAMPLE_EVENTS } from '$lib/server/events/data/club-events';
 import { fromGCal, listUpcomingEvents } from '$lib/server/events/gcal';
+import { fromICal, downloadKnownICS } from '$lib/server/events/ical';
 import { allEvents } from '$lib/server/events/cache';
 import type { ClubEvent } from '$lib/public/events/event';
 import { ALL } from '$lib/public/blog/utils';
@@ -11,7 +12,7 @@ export async function GET({ params }: RequestEvent<RouteParams>) {
   const events = await getData();
 
   if (events.length === 0) {
-    return new Response('[]', { status: 204 });
+    return new Response('[]', { status: 200 });
   }
 
   const filteredEvents =
@@ -35,18 +36,39 @@ async function getData(): Promise<ClubEvent[]> {
 
   let data = allEvents.get();
   if (!data) {
-    const upcomingEvents = await listUpcomingEvents();
-    // To generate 'src/lib/server/events/data/gcal-events.json', uncomment the
-    // following lines of code then visit http://localhost:5173/events/:
-    //
-    // const { writeFileSync } = await import('node:fs');
-    // writeFileSync(
-    //   'src/lib/server/events/data/gcal-events.json',
-    //   JSON.stringify(upcomingEvents, null, 2),
-    // );
-    //
-    // Remember to comment out the above lines of code before committing.
-    data = fromGCal(upcomingEvents);
+    const timezone = 'America/Los_Angeles';
+    data = (
+      await Promise.all([
+        (async () => {
+          try {
+            const upcomingEvents = await listUpcomingEvents();
+            // To generate 'src/lib/server/events/data/gcal-events.json', uncomment the
+            // following lines of code then visit http://localhost:5173/events/:
+            //
+            // const { writeFileSync } = await import('node:fs');
+            // writeFileSync(
+            //   'src/lib/server/events/data/gcal-events.json',
+            //   JSON.stringify(upcomingEvents, null, 2),
+            // );
+            //
+            // Remember to comment out the above lines of code before committing.
+            return fromGCal(upcomingEvents, timezone);
+          } catch (err) {
+            console.warn('could not load events from Google Calendar', err);
+            return [];
+          }
+        })(),
+        (async () => {
+          try {
+            const knownEvents = await downloadKnownICS();
+            return fromICal(knownEvents, timezone);
+          } catch (err) {
+            console.warn('could not load events from ICal', err);
+            return [];
+          }
+        })(),
+      ])
+    ).reduce((acc, val) => acc.concat(val), []);
     allEvents.set(data);
   }
 


### PR DESCRIPTION
This commit adds support for parsing ICS calendars using the ICal
standard format in addition to the existing Google Calendar API.

The new commit also contains a hard-coded array of ICS calendar links,
currently only containing ics.acmcsuf.com. In the future, more links may
be added to this.

A hard-coded array was chosen over an environment variable because
environment variables cannot express arrays as easily. That said, if
there are any private calendars, then they can be used as such:

    const KnownCalendars = [
      "public1.ics",
      "public2.ics",
      SECRET_ICS_X,
      SECRET_ICS_Y,
    ]

In the future, if ics.acmcsuf.com is proven to work well enough, the
Google Calendar API could even be completely phased out.

NOTE: It is worth pointing out that this ICS code currently *does not
support recurring events*. This is because ics.acmcsuf.com doesn't do
recurring events.