### PR TITLE
Fixed overflow on teams component (landing page)

### DIFF
--- a/src/routes/(site)/teams.svelte
+++ b/src/routes/(site)/teams.svelte
@@ -148,7 +148,7 @@
       grid-template-columns: 1fr 1fr;
       align-items: baseline;
       justify-content: center;
-      width: 70%;
+      width: 70ch;
       gap: 2em;
     }
   }

--- a/src/routes/(site)/teams.svelte
+++ b/src/routes/(site)/teams.svelte
@@ -121,10 +121,21 @@
     }
 
     section .hero-inner-container {
+      grid-template-columns: 1fr;
       gap: 2em;
       margin: 1em;
     }
 
+    section .hero-inner-container .hero-text {
+      text-align: start;
+    }
+
+    section .hero-inner-container .hero-text .discover-button {
+      justify-self: center;
+    }
+  }
+
+  @media screen and (min-width: 768px) {
     section .hero-inner-container .team-row1-container {
       display: grid;
       grid-template-columns: 1fr 1fr 1fr;
@@ -139,14 +150,6 @@
       justify-content: center;
       width: 70%;
       gap: 2em;
-    }
-
-    section .hero-inner-container .hero-text {
-      text-align: start;
-    }
-
-    section .hero-inner-container .hero-text .discover-button {
-      justify-self: center;
     }
   }
 </style>


### PR DESCRIPTION
Aims to fix #1006 

https://github.com/EthanThatOneKid/acmcsuf.com/assets/112128328/8fbe46f3-6512-42a2-851c-c1caebe05bdc

As of now, this will fix the overflow caused by the teams component, but we might need to explore a way to contain width of the component and having two badges at medium screen sizes, while maintain the current look on desktop view.