### PR TITLE
add hyphen in teams.svelte, fixing grammar

### DIFF
--- a/src/routes/(site)/teams.svelte
+++ b/src/routes/(site)/teams.svelte
@@ -31,7 +31,7 @@
       <div class="hero-inner-container">
         <img src="/assets/dev-logo.svg" alt="Dev Team Badge" />
         <div class="size-md brand-med hero-text">
-          <span><span class="acm-bluer">Develop</span> semester long projects to show your mom</span
+          <span><span class="acm-bluer">Develop</span> semester-long projects to show your mom</span
           >
         </div>
       </div>


### PR DESCRIPTION
"semester-long" should be hyphenated. This patch adds a hyphen where it is currently missing.

Signed-off-by: Amy Parker <amy@amyip.net>