### PR TITLE
reflect new size-limit in contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,7 +55,7 @@ npm run test:coverage
 ### NPM bloat
 
 In this project, we set a threshold for how large the `/node_modules` folder can become after an `npm install`.
-In our [`package.json`](package.json), we set the size to 50 MB.
+In our [`package.json`](package.json), we set the size to 256 MB.
 
 To test the size of the dependencies in your local workspace, run `npm run test:size`.
 


### PR DESCRIPTION
The contributing guide currently lists the size-limit as 50 MB. This is incorrect, as the size-limit is (and has been for some time) 256 MB. This patch updates the contributing guide to reflect that difference.

Signed-off-by: Amy Parker <amy@amyip.net>