### PR TITLE
upgrade vulnerable dependency versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -681,9 +681,9 @@
       }
     },
     "node_modules/@sveltejs/kit": {
-      "version": "1.30.3",
-      "resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-1.30.3.tgz",
-      "integrity": "sha512-0DzVXfU4h+tChFvoc8C61IqErCyskD4ydSIDjpKS2lYlEzIYrtYrY7juSqACFxqcvZAnOEXvSY+zZ8br0+ZMMg==",
+      "version": "1.30.4",
+      "resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-1.30.4.tgz",
+      "integrity": "sha512-JSQIQT6XvdchCRQEm7BABxPC56WP5RYVONAi+09S8tmzeP43fBsRlr95bFmsTQM2RHBldfgQk+jgdnsKI75daA==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -699,7 +699,7 @@
         "set-cookie-parser": "^2.6.0",
         "sirv": "^2.0.2",
         "tiny-glob": "^0.2.9",
-        "undici": "~5.26.2"
+        "undici": "^5.28.3"
       },
       "bin": {
         "svelte-kit": "svelte-kit.js"
@@ -4314,9 +4314,9 @@
       "dev": true
     },
     "node_modules/undici": {
-      "version": "5.26.5",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.26.5.tgz",
-      "integrity": "sha512-cSb4bPFd5qgR7qr2jYAi0hlX9n5YKK2ONKkLFkxl+v/9BvC0sOpZjBHDBSXc5lWAf5ty9oZdRXytBIHzgUcerw==",
+      "version": "5.28.3",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.28.3.tgz",
+      "integrity": "sha512-3ItfzbrhDlINjaP0duwnNsKpDQk3acHI3gVJ1z4fmwMK31k5G9OVIAMLSIaP6w4FaGkaAkN6zaQO9LUvZ1t7VA==",
       "dev": true,
       "dependencies": {
         "@fastify/busboy": "^2.0.0"
@@ -4364,9 +4364,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-4.5.1.tgz",
-      "integrity": "sha512-AXXFaAJ8yebyqzoNB9fu2pHoo/nWX+xZlaRwoeYUxEqBO+Zj4msE5G+BhGBll9lYEKv9Hfks52PAF2X7qDYXQA==",
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-4.5.2.tgz",
+      "integrity": "sha512-tBCZBNSBbHQkaGyhGCDUGqeo2ph8Fstyp6FMSvTtsXeZSPpSMGlviAOav2hxVTqFcx8Hj/twtWKsMJXNY0xI8w==",
       "dev": true,
       "dependencies": {
         "esbuild": "^0.18.10",


### PR DESCRIPTION
The following dependencies were listed as vulnerable by npm audit:
- @sveltejs/kit: v1.30.3->v1.30.4 due to (low):
  - undici: v5.26.5->v5.28.3 (low)
- vite: v4.5.1 -> v4.5.2 (**high**)

This patch fixes the following vulnerabilities:
- undici: GHSA-3787-6prv-h9w3 (proxy-authorization header...)
- vite: GHSA-c24v-8rfc-w8vw (server.fs.deny bypass...)

Except for svelte-check (fails due to lack of environment), all checks pass per `npm run all`. Site loads correctly on `npm run dev`.

Signed-off-by: Amy Parker <amy@amyip.net>