### PR TITLE
bump package version to 6.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "acmcsuf.com",
   "description": "Official website of CSUF's ACM club.",
-  "version": "5.0.0",
+  "version": "6.0.0",
   "private": true,
   "type": "module",
   "homepage": "https://acmcsuf.com/",


### PR DESCRIPTION
This patch bumps the `acmcsuf.com` package version to 6.0.0 from 5.0.0.

Fixes: #1025