### PR TITLE
fix game dev anchor styling on about page

### DIFF
--- a/src/routes/(site)/about/officer-profile.svelte
+++ b/src/routes/(site)/about/officer-profile.svelte
@@ -44,7 +44,7 @@
       .join(', ') ?? '';
 
   $: titleHTML = Object.values(TEAMS).reduce((s, t) => {
-    if (t.id === 'dev' && team?.id === 'gamedev') {
+    if (t.id === 'dev' && s.includes('Game Dev')) {
       return s;
     }
 


### PR DESCRIPTION
Sorry I didn't make an issue first y'all  😞 
- Fixes the issue where game dev anchor tags show up as dev tags on the about page

### Before
<img width="740" alt="image" src="https://github.com/EthanThatOneKid/acmcsuf.com/assets/40745961/15427c80-9091-4355-a234-07c4eb852cd1">

### After
<img width="662" alt="image" src="https://github.com/EthanThatOneKid/acmcsuf.com/assets/40745961/ab7c3462-beee-433d-9cf9-dec3f187c9c5">
