### PR TITLE
Fix small changes on `acmcsuf.com/sitemap`

### DIFF
--- a/src/lib/components/footer/footer.svelte
+++ b/src/lib/components/footer/footer.svelte
@@ -5,6 +5,7 @@
   const footerItems = [
     { title: 'Source Code', path: '/code' },
     { title: 'Report a Bug', path: '/bug' },
+    { title: 'Sitemap', path: '/sitemap' },
     { title: 'COVID-19 Policy', path: '/covid-19' },
     { title: 'Privacy Policy', path: '/privacy' },
   ];

--- a/src/routes/(site)/sitemap/data.ts
+++ b/src/routes/(site)/sitemap/data.ts
@@ -5,7 +5,7 @@ const siteMap: SiteMap = {
     {
       id: 'homepage',
       title: 'Home',
-      link: '',
+      link: '/',
     },
     {
       id: 'eventspage',


### PR DESCRIPTION
Homepage appropriately redirects and sitemap is officially added to the footer.

![image](https://github.com/EthanThatOneKid/acmcsuf.com/assets/60043611/34588f18-bbb8-4b70-b684-fd789127ae35)

Fix #1072.