### PR TITLE
add Nick's Server Team Member position

### DIFF
--- a/src/lib/public/board/data/officers.json
+++ b/src/lib/public/board/data/officers.json
@@ -987,7 +987,10 @@
     "fullName": "Nick Goulart",
     "picture": "nick-goulart.webp",
     "positions": {
-      "F24": [{ "title": "Dev Officer", "tier": 19 }]
+      "F24": [
+        { "title": "Dev Officer", "tier": 19 },
+        { "title": "Server Team Member", "tier": 35 }
+      ]
     },
     "discord": "@realbignick"
   },

--- a/src/lib/public/board/data/teams.json
+++ b/src/lib/public/board/data/teams.json
@@ -41,7 +41,7 @@
     "logoSrc": "/assets/dev-logo.svg",
     "oldLogoSrc": "/assets/dev-logo-old.svg",
     "color": "var(--acm-bluer)",
-    "tiers": [17, 18, 19]
+    "tiers": [17, 18, 19, 35]
   },
   {
     "id": "gamedev",

--- a/src/lib/public/board/data/tiers.json
+++ b/src/lib/public/board/data/tiers.json
@@ -18,6 +18,7 @@
   "Design Officer": { "id": 16, "index": 900 },
   "Dev Team Lead": { "id": 17, "index": 950 },
   "Dev Project Manager": { "id": 18, "index": 1000 },
+  "Server Team Member": { "id": 35, "index": 1750 },
   "Dev Officer": { "id": 19, "index": 1050 },
   "AI Team Lead": { "id": 20, "index": 1100 },
   "AI Officer": { "id": 21, "index": 1150 },


### PR DESCRIPTION
This patchset adds the Server Team Member position, adds the position to Dev (it's technically Dev-OSS but as far as I know one tier can't be represented by multiple teams), and then adds the position to Nick's list.

Signed-off-by: Amy Parker <amy@amyip.net>