### PR TITLE
fix: dark mode 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1326,11 +1326,11 @@
       }
     },
     "node_modules/axobject-query": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-3.2.1.tgz",
-      "integrity": "sha512-jsyHu61e6N4Vbz/v18DHwWYKK0bSWLqn47eeDSKPB7m8tqMHF9YJ+mhIk2lVteyZrY8tnSj/jHOv4YiTCuCJgg==",
-      "dependencies": {
-        "dequal": "^2.0.3"
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",
+      "integrity": "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==",
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/balanced-match": {
@@ -1386,12 +1386,12 @@
       }
     },
     "node_modules/braces": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
       "dev": true,
       "dependencies": {
-        "fill-range": "^7.0.1"
+        "fill-range": "^7.1.1"
       },
       "engines": {
         "node": ">=8"
@@ -2271,9 +2271,9 @@
       }
     },
     "node_modules/fill-range": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
       "dev": true,
       "dependencies": {
         "to-regex-range": "^5.0.1"
@@ -3139,12 +3139,12 @@
       }
     },
     "node_modules/micromatch": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
-      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
       "dev": true,
       "dependencies": {
-        "braces": "^3.0.2",
+        "braces": "^3.0.3",
         "picomatch": "^2.3.1"
       },
       "engines": {
@@ -4232,16 +4232,17 @@
       }
     },
     "node_modules/svelte": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/svelte/-/svelte-4.2.8.tgz",
-      "integrity": "sha512-hU6dh1MPl8gh6klQZwK/n73GiAHiR95IkFsesLPbMeEZi36ydaXL/ZAb4g9sayT0MXzpxyZjR28yderJHxcmYA==",
+      "version": "4.2.19",
+      "resolved": "https://registry.npmjs.org/svelte/-/svelte-4.2.19.tgz",
+      "integrity": "sha512-IY1rnGr6izd10B0A8LqsBfmlT5OILVuZ7XsI0vdGPEvuonFV7NYEUK4dAkm9Zg2q0Um92kYjTpS1CAP3Nh/KWw==",
       "dependencies": {
         "@ampproject/remapping": "^2.2.1",
         "@jridgewell/sourcemap-codec": "^1.4.15",
         "@jridgewell/trace-mapping": "^0.3.18",
+        "@types/estree": "^1.0.1",
         "acorn": "^8.9.0",
         "aria-query": "^5.3.0",
-        "axobject-query": "^3.2.1",
+        "axobject-query": "^4.0.0",
         "code-red": "^1.0.3",
         "css-tree": "^2.3.1",
         "estree-walker": "^3.0.3",

--- a/src/lib/components/bw-icon/bw-icon.svelte
+++ b/src/lib/components/bw-icon/bw-icon.svelte
@@ -18,13 +18,13 @@
 />
 
 <style lang="scss">
-  :global(body.dark) {
+  :global(html[data-theme='dark']) {
     .filter-dark {
       filter: invert(1);
     }
   }
 
-  :global(body:not(.dark)) {
+  :global(html[data-theme='light']) {
     .filter-light {
       filter: invert(1);
     }

--- a/src/routes/(site)/blog/[id]/syntax-highlight.css
+++ b/src/routes/(site)/blog/[id]/syntax-highlight.css
@@ -75,7 +75,7 @@
 }
 
 @media (prefers-color-scheme: light) {
-  body:not(.dark) {
+  html[data-theme='light'] {
     --color-prettylights-syntax-comment: #6a737d;
     --color-prettylights-syntax-constant: #005cc5;
     --color-prettylights-syntax-entity: #6f42c1;
@@ -111,7 +111,7 @@
 }
 
 @media (prefers-color-scheme: dark) {
-  body:not(.light) {
+  html[data-theme='dark'] {
     --color-prettylights-syntax-comment: #8b949e;
     --color-prettylights-syntax-constant: #79c0ff;
     --color-prettylights-syntax-entity: #d2a8ff;

--- a/src/routes/(site)/quiz/progress-bar.svelte
+++ b/src/routes/(site)/quiz/progress-bar.svelte
@@ -47,22 +47,22 @@
     }
   }
 
-  :global(.light) {
+  :global(html[data-theme='light']) {
     --progress-bg: rgba(224, 224, 224, 0.918);
   }
 
-  :global(.dark) {
+  :global(html[data-theme='dark']) {
     --progress-bg: #808080;
   }
 
   @media (prefers-color-scheme: light) {
-    :global(body:not(.dark)) {
+    :global(html[data-theme='light']) {
       --progress-bg: rgba(224, 224, 224, 0.918);
     }
   }
 
   @media (prefers-color-scheme: dark) {
-    :global(body:not(.light)) {
+    :global(html[data-theme='dark']) {
       --progress-bg: #808080;
     }
   }

--- a/src/routes/(site)/quiz/quiz.svelte
+++ b/src/routes/(site)/quiz/quiz.svelte
@@ -428,22 +428,22 @@
     }
   }
 
-  :global(.light) {
+  :global(html[data-theme='light']) {
     --quiz-bg: rgba(243, 243, 243, 0.795);
   }
 
-  :global(.dark) {
+  :global(html[data-theme='dark']) {
     --quiz-bg: #6868682a;
   }
 
   @media (prefers-color-scheme: light) {
-    :global(body:not(.dark)) {
+    :global(html[data-theme='light']) {
       --quiz-bg: rgba(243, 243, 243, 0.795);
     }
   }
 
   @media (prefers-color-scheme: dark) {
-    :global(body:not(.light)) {
+    :global(html[data-theme='dark']) {
       --quiz-bg: #6868682a;
     }
   }


### PR DESCRIPTION
Fixes #1114 

![image](https://github.com/user-attachments/assets/a9cf0d96-e51c-4afd-a95c-4d1324681cde)

These icons were affected because of a change to how we handled dark mode. In order to take advantage of SSR and prevent theme flickering on page load, we used html data attributes and cookies to persist preferences. That means we no longer needed to have the `.dark` and the `.light` class names, which I forgot to check for other places where the codebase used those.

Switched from using `body.light` and `body.dark` to `html[data-theme='light'` and `html[data-theme='dark'` instead.