### PR TITLE
Add Mark and David as Node Buds officers

### DIFF
--- a/src/lib/public/board/data/officers.json
+++ b/src/lib/public/board/data/officers.json
@@ -238,7 +238,10 @@
     "picture": "mark-ryan-garcia.webp",
     "positions": {
       "S24": [{ "title": "Marketing Officer", "tier": 9 }],
-      "F24": [{ "title": "Marketing Team Lead", "tier": 8 }]
+      "F24": [
+        { "title": "Marketing Team Lead", "tier": 8 },
+        { "title": "Node Buds Officer", "tier": 26 }
+      ]
     },
     "discord": "@xnaym"
   },
@@ -840,7 +843,8 @@
       ],
       "F24": [
         { "title": "Treasurer", "tier": 4 },
-        { "title": "Algo Officer", "tier": 12 }
+        { "title": "Algo Officer", "tier": 12 },
+        { "title": "Node Buds Officer", "tier": 26 }
       ]
     },
     "discord": "@davidjsolano"


### PR DESCRIPTION
I added more officers to the Node Buds team. Look at picture for reference.

![Screenshot 2024-10-01 223623](https://github.com/user-attachments/assets/45befb91-9b2c-4fd2-abfc-dae3c6af14b9)
