### PR TITLE
Fixed Incorrect Percentage Calculation on Quiz Page and Game Dev always displaying 0%

### DIFF
--- a/src/lib/public/quiz/questions/types.ts
+++ b/src/lib/public/quiz/questions/types.ts
@@ -18,7 +18,7 @@ export enum TeamMatch {
   DESIGN = 'Design',
   AI = 'AI',
   OSS = 'OSS',
-  GAMEDEV = 'Game Dev',
+  GAMEDEV = 'GameDev',
   ICPC = 'ICPC',
   TEAMLESS = 'N/A',
 }

--- a/src/routes/(site)/quiz/quiz.svelte
+++ b/src/routes/(site)/quiz/quiz.svelte
@@ -83,9 +83,16 @@
       ?.shift() as TeamMatch;
   }
 
+  function totalTallies(tallies: Record<string, number>) {
+    let totalTallies = 0;
+    Object.values(tallies).forEach(value => totalTallies += value);
+    return totalTallies;
+  }
+
   $: talliedResponses = tallyResponses(responses);
 
   $: match = maxTallies(talliedResponses);
+  $: sumOfTallies = totalTallies(talliedResponses);
 
   // local storage stuff
   let quizStorage: QuizStorage | undefined;
@@ -173,7 +180,7 @@
         </h2>
         <img src={TEAMS[match].logoSrc} alt={`${match} icon`} class="team-icon" />
         <ProgressBar
-          progress={(talliedResponses[match] / data.questions.length) * 100}
+          progress={(talliedResponses[match] / sumOfTallies) * 100}
           fillColor={TEAMS[match].color}
         />
       </div>
@@ -193,7 +200,7 @@
 
           <ProgressBar
             progress={talliedResponses[otherMatch]
-              ? (talliedResponses[otherMatch] / data.questions.length) * 100
+              ? (talliedResponses[otherMatch] / sumOfTallies) * 100
               : 0}
             fillColor={team.color}
           />

--- a/src/routes/(site)/quiz/quiz.svelte
+++ b/src/routes/(site)/quiz/quiz.svelte
@@ -85,7 +85,7 @@
 
   function totalTallies(tallies: Record<string, number>) {
     let totalTallies = 0;
-    Object.values(tallies).forEach(value => totalTallies += value);
+    Object.values(tallies).forEach((value) => (totalTallies += value));
     return totalTallies;
   }
 


### PR DESCRIPTION
Issue #1081 
### Fixed: Game Dev displaying incorrectly
In src/lib/public/quiz/questions/types.ts TeamMatch, change GAMEDEV = 'Game Dev', to GAMEDEV = 'GameDev',
After doing the said change and making choices to get gamedev match:
![image](https://github.com/user-attachments/assets/517e054d-2983-4be3-9428-c0432e0ab464)

### Fixed: Percentage counting incorrectly
Changed the formula to {(talliedResponses[match] / sumOfTallies) * 100}, where sumOfTallies is calculated by a function:
```
 function totalTallies(tallies: Record<string, number>) {
    let totalTallies = 0;
    Object.values(tallies).forEach(value => totalTallies += value);
    return totalTallies;
  }
```
![image](https://github.com/user-attachments/assets/dc5806b4-e5b3-41cb-917a-df7db1787dfb)
