### PR TITLE
Fixed Redirect doesn't work when clicking on team tiles for Quiz Page.

### DIFF
--- a/src/lib/public/quiz/questions/types.ts
+++ b/src/lib/public/quiz/questions/types.ts
@@ -13,13 +13,13 @@ export interface QuizResponse {
 }
 
 export enum TeamMatch {
-  ALGO = 'Algo',
-  DEV = 'Dev',
-  DESIGN = 'Design',
-  AI = 'AI',
-  OSS = 'OSS',
-  GAMEDEV = 'GameDev',
-  ICPC = 'ICPC',
+  ALGO = 'algo',
+  DEV = 'dev',
+  DESIGN = 'design',
+  AI = 'ai',
+  OSS = 'oss',
+  GAMEDEV = 'gamedev',
+  ICPC = 'icpc',
   TEAMLESS = 'N/A',
 }
 


### PR DESCRIPTION
Similar to #1081 , issue was with casing in TeamMatch enum. It wasn't consistent with lowercase id's we get from the quiz data. So I went ahead and changed all TeamMatch enums to lowercase, which fixed the issue. 
<img width="201" alt="image" src="https://github.com/user-attachments/assets/9dff3e2d-48a7-4758-927a-076039e77a19">

Unrelated to this issue, design team page for this quiz has a broken image link. 
<img width="1434" alt="image" src="https://github.com/user-attachments/assets/f881ad01-3867-4c1d-a047-a485ae41ac5c">
