### PR TITLE
Add "image" type to schema

### DIFF
--- a/src/routes/(site)/+page.svelte
+++ b/src/routes/(site)/+page.svelte
@@ -19,6 +19,7 @@
       "description": "The Association for Computing Machinery at California State University, Fullerton",
       "url": "https://acmcsuf.com/",
       "logo": "https://acmcsuf.com/favicon.png",
+      "image": "https://acmcsuf.com/assets/capy-power.svg"
       "email": "mailto:acmcsufullerton@gmail.com",
       "sameAs": [
         "https://fullerton.campuslabs.com/engage/organization/acm",


### PR DESCRIPTION
Schema.org has an image type that isn't explicitly mentioned in the meta tags that we created. Although this cannot be tested in dev, pushing this change should not affect the rest of prod.
![image](https://github.com/user-attachments/assets/8f44d959-1bd7-456b-9388-633b2c9d826e)

Fix #1157.