### PR TITLE
Fix gamedev syntax highlighting on marketing team

### DIFF
--- a/src/routes/(site)/teams/officer-profile.svelte
+++ b/src/routes/(site)/teams/officer-profile.svelte
@@ -28,7 +28,7 @@
   }
 
   $: titleHTML = Object.values(TEAMS).reduce((s, t) => {
-    if (t.id === 'dev' && team?.id === 'gamedev') {
+    if (t.id === 'dev' && officerPosition.includes('Game')) {
       return s;
     }
 


### PR DESCRIPTION
The previous if statement would only work if the current team was 'gamedev' and the current iteration check was 'dev', which doesn't work when on marketing or other teams.

This fix tweaks the if statement to specify the phrase "game" to ensure that the highlighting would be on the appropriate team.
![image](https://github.com/user-attachments/assets/1f11dfa1-164d-4055-829b-1092039c3059)

Fix #1153.
