### PR TITLE
Remove Ahad Ahmad from Fall 2025 Board

### DIFF
--- a/src/lib/public/board/data/officers.json
+++ b/src/lib/public/board/data/officers.json
@@ -1238,8 +1238,7 @@
     "picture": "ahad-munir-ahmad.webp",
     "positions": {
       "F24": [{ "title": "Dev Project Manager", "tier": 18 }],
-      "S25": [{ "title": "Dev Officer", "tier": 19 }],
-      "F25": [{ "title": "Dev Officer", "tier": 19 }]
+      "S25": [{ "title": "Dev Officer", "tier": 19 }]
     },
     "discord": "@adj1200"
   },


### PR DESCRIPTION
Ahad resigned from the Dev team, so I removed him from /teams.
![image](https://github.com/user-attachments/assets/c52f4963-a0e8-4281-8d2d-d712b054ffb3)
