### PR TITLE
Fix Join Button Redirection

### DIFF
--- a/src/routes/(site)/events/event.svelte
+++ b/src/routes/(site)/events/event.svelte
@@ -34,6 +34,11 @@
     }
     details.open = true;
   });
+
+  function handleClick() {
+    shown = !shown;
+    window.open(info.meetingLink, '_blank', 'noopener,noreferrer');
+  }
 </script>
 
 <div
@@ -67,16 +72,7 @@
         </time>
       </p>
 
-      <a
-        class="event-join size-sm"
-        href={info.meetingLink}
-        role="button"
-        target="_blank"
-        rel="noopener noreferrer"
-        on:click={(/* janky hack */) => {
-          shown = !shown;
-        }}>Join</a
-      >
+      <button class="event-join size-sm" on:click={handleClick}> Join </button>
     </summary>
 
     <noscript>


### PR DESCRIPTION
Join button on /events for every event should now redirect to the acm discord server. The assumption for why it didn't work previously is because something was being overridden when using the anchor tag so it's now replaced with a button tag that redirects to the server.