### PR TITLE
Reordered ICPC Lead

### DIFF
--- a/src/lib/public/board/data/officers.json
+++ b/src/lib/public/board/data/officers.json
@@ -1259,9 +1259,9 @@
         { "title": "Marketing Officer", "tier": 9 }
       ],
       "F25": [
+        { "title": "ICPC Lead", "tier": 34 },
         { "title": "Algo Officer", "tier": 12 },
-        { "title": "Game Dev Officer", "tier": 23 },
-        { "title": "ICPC Lead", "tier": 34 }
+        { "title": "Game Dev Officer", "tier": 23 }
       ]
     },
     "discord": "@baremetal_alchemist"


### PR DESCRIPTION
I reordered ICPC Lead to be the first role, so Noah's roles are now displayed as "ICPC Lead, Algo Officer, Game Dev Officer".
<img width="1873" height="992" alt="image" src="https://github.com/user-attachments/assets/6d17568c-dd01-4804-97ba-576f84f0040e" />
