### PR TITLE
Update ID for ICPC Lead Role

### DIFF
--- a/src/lib/public/board/data/officers.json
+++ b/src/lib/public/board/data/officers.json
@@ -1259,7 +1259,7 @@
         { "title": "Marketing Officer", "tier": 9 }
       ],
       "F25": [
-        { "title": "ICPC Lead", "tier": 34 },
+        { "title": "ICPC Lead", "tier": 27 },
         { "title": "Algo Officer", "tier": 12 },
         { "title": "Game Dev Officer", "tier": 23 }
       ]

--- a/src/lib/public/board/data/tiers.json
+++ b/src/lib/public/board/data/tiers.json
@@ -35,5 +35,5 @@
   "ICC Representative": { "id": 31, "index": 1600 },
   "Open Source Team Lead": { "id": 32, "index": 1650 },
   "Open Source Officer": { "id": 33, "index": 1700 },
-  "ICPC Lead": { "id": 34, "index": 1750 }
+  "ICPC Lead": { "id": 27, "index": 1750 }
 }


### PR DESCRIPTION
The reason the ICPC Lead was showing along the nodebuds team is because both roles had the same id, 34. To fix this, I added a unique id for the role, which is 27! 

<img width="1470" height="797" alt="Screenshot 2025-09-20 at 9 24 02 PM" src="https://github.com/user-attachments/assets/3f20bd6a-6ae9-4d87-b8bf-4f8ec96e4fad" />
