### PR TITLE
fix: Use `css-tree` instead of `css` for parsing `/colors`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@googleapis/calendar": "^7.0.0",
         "cropperjs": "^1.5.13",
+        "css-tree": "^3.1.0",
         "googleapis": "^134.0.0",
         "html-to-text": "^9.0.5",
         "lc-dailies": "github:acmcsufoss/lc-dailies#npm",
@@ -3158,6 +3159,19 @@
         "source-map-resolve": "^0.6.0"
       }
     },
+    "node_modules/css-tree": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.1.0.tgz",
+      "integrity": "sha512-0eW44TGN5SQXU1mWSkKwFstI/22X2bG1nYzZTYMAWjylYURhse752YgbE4Cx46AC+bAvI+/dYTPRk1LqSUnu6w==",
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.12.2",
+        "source-map-js": "^1.0.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
     "node_modules/cssesc": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
@@ -4660,6 +4674,12 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/mdn-data": {
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.12.2.tgz",
+      "integrity": "sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==",
+      "license": "CC0-1.0"
+    },
     "node_modules/merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -5850,7 +5870,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,6 @@
         "@types/html-to-text": "^9.0.1",
         "@types/qrcode": "^1.5.1",
         "@types/rss": "^0.0.30",
-        "css": "^3.0.0",
         "eslint": "^9.35.0",
         "eslint-config-prettier": "^8.5.0",
         "eslint-plugin-svelte": "^3.12.3",
@@ -2807,19 +2806,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/atob": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
-      "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
-      "dev": true,
-      "license": "(MIT OR Apache-2.0)",
-      "bin": {
-        "atob": "bin/atob.js"
-      },
-      "engines": {
-        "node": ">= 4.5.0"
-      }
-    },
     "node_modules/axobject-query": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",
@@ -3147,18 +3133,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/css": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/css/-/css-3.0.0.tgz",
-      "integrity": "sha512-DG9pFfwOrzc+hawpmqX/dHYHJG+Bsdb0klhyi1sDneOgGOXy9wQIC8hzyVp1e4NRYDBdxcylvywPkkXCHAzTyQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "^2.0.4",
-        "source-map": "^0.6.1",
-        "source-map-resolve": "^0.6.0"
-      }
-    },
     "node_modules/css-tree": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.1.0.tgz",
@@ -3209,16 +3183,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/decode-uri-component": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.2.tgz",
-      "integrity": "sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10"
       }
     },
     "node_modules/deep-eql": {
@@ -4373,21 +4337,6 @@
       "engines": {
         "node": ">=0.8.19"
       }
-    },
-    "node_modules/inherits": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/is-arrayish": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.4.tgz",
-      "integrity": "sha512-m6UrgzFVUYawGBh1dUsWR5M2Clqic9RVXC/9f8ceNlv2IcO9j9J/z8UoCLPqtsPBFNzEpfR3xftohbfqDx8EQA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/is-binary-path": {
       "version": "2.1.0",
@@ -5856,16 +5805,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -5873,18 +5812,6 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/source-map-resolve": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.6.0.tgz",
-      "integrity": "sha512-KXBr9d/fO/bWo97NXsPIAW1bFSBOuCnjbNTBMO7N59hsv5i9yzRDfcYwwt0l04+VqnKC+EwzvJZIP/qkuMgR/w==",
-      "deprecated": "See https://github.com/lydell/source-map-resolve#deprecated",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "atob": "^2.1.2",
-        "decode-uri-component": "^0.2.0"
       }
     },
     "node_modules/stackback": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4338,6 +4338,14 @@
         "node": ">=0.8.19"
       }
     },
+    "node_modules/is-arrayish": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.4.tgz",
+      "integrity": "sha512-m6UrgzFVUYawGBh1dUsWR5M2Clqic9RVXC/9f8ceNlv2IcO9j9J/z8UoCLPqtsPBFNzEpfR3xftohbfqDx8EQA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/is-binary-path": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
     "@types/html-to-text": "^9.0.1",
     "@types/qrcode": "^1.5.1",
     "@types/rss": "^0.0.30",
-    "css": "^3.0.0",
     "eslint": "^9.35.0",
     "eslint-config-prettier": "^8.5.0",
     "eslint-plugin-svelte": "^3.12.3",

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
   "dependencies": {
     "@googleapis/calendar": "^7.0.0",
     "cropperjs": "^1.5.13",
+    "css-tree": "^3.1.0",
     "googleapis": "^134.0.0",
     "html-to-text": "^9.0.5",
     "lc-dailies": "github:acmcsufoss/lc-dailies#npm",

--- a/scripts/generate-colors/colors.js
+++ b/scripts/generate-colors/colors.js
@@ -1,4 +1,4 @@
-import { parse } from 'css';
+import { parse } from 'css-tree';
 
 export function parseGlobalCSS(source) {
   const ast = parse(source);

--- a/src/routes/(site)/colors/+page.svelte
+++ b/src/routes/(site)/colors/+page.svelte
@@ -23,9 +23,11 @@
     </p>
 
     <table>
-      {#each data.colors as color (color.id)}
-        <Color data={color} />
-      {/each}
+      <tbody>
+        {#each data.colors as color (color.id)}
+          <Color data={color} />
+        {/each}
+      </tbody>
     </table>
   </section>
 


### PR DESCRIPTION
the npm package `css` has a depreciated dependency that's generating a warning on `npm install`, switching to `css-tree` resolves the issue as a drop in replacement.
```
npm warn deprecated source-map-resolve@0.6.0: See https://github.com/lydell/source-map-resolve#deprecated
```

Also introduced a `tbody` element on the colors page to silence this warning:
```
node_invalid_placement_ssr: `<tr>` (src/routes/(site)/colors/color.svelte:12:0) cannot be a child of `<table
>` (src/routes/(site)/colors/+page.svelte:25:4). `<table>` only allows these children: `<caption>`, `<colgro
up>`, `<tbody>`, `<thead>`, `<tfoot>`, `<style>`, `<script>`, `<template>`

This can cause content to shift around as the browser repairs the HTML, and will likely result in a `hydrati
on_mismatch` warning.
```
# Reproducing
First, on `main`:
```sh
rm -r node_modules && npm i
```
Observe depreciation warning.

Then, on this branch:
```sh
rm -r node_modules && npm i
```
Warning should be gone.