### PR TITLE
simplify cloudflare preview

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "start": "npm run dev",
     "dev": "wrangler dev",
     "build": "vite build",
-    "preview": "vite build -- mode production && wrangler deploy -e=preview",
+    "preview": "vite build -- mode production && wrangler versions upload -e production",
     "test": "vitest --run",
     "test:watch": "vitest",
     "test:size": "npm run build && size-limit",
@@ -42,7 +42,7 @@
     "host": "npm run all && npm run preview",
     "all": "npm run lint && npm run format && npm run check && npm run build && npm t",
     "generate:colors": "node scripts/generate-colors/index.js",
-    "deploy": "vite build --mode production && wrangler deploy -e=production"
+    "deploy": "vite build --mode production && wrangler deploy -e production"
   },
   "devDependencies": {
     "@eslint/js": "^9.35.0",

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -18,15 +18,26 @@ invocation_logs = true
 persist = true
 
 # ==== Route/Domain Configuration ==================================================================
-workers_dev = true
-# https://developers.cloudflare.com/workers/configuration/previews/
-preview_urls = true  # To use: `wrangler versions upload -e [env-name]`
+# https://developers.cloudflare.com/workers/configuration/routing/
 
 # This uses vars defined in .env.production (make sure debug is off!)
 [env.production]
 routes = [
   { pattern = "acmcsuf.com", custom_domain = true }
 ]
+# https://developers.cloudflare.com/workers/configuration/previews/
+# To create a preview deployment, use one of the following:
+#   `wrangler versions upload -e [env-name]`
+#   `wrangler versions upload -e [env-name] --preview-alias [alias-name]`
+# The latter puts the alias name in the URL, useful for tracking an in-progress feature.
+# Live preview URLs can be found in the "Deployments" tab of the Worker.
+workers_dev = true
+preview_urls = true
 
-# More environments like [env.staging] can be created here, and they can be deployed
-# with `wrangler deploy -e staging` or whatever the env is called.
+# More environments can be created here, and they can be deployed by running
+# `wrangler deploy -e [env-name]`, and they'll use a `.env.[env-name]` file.
+# Example:
+
+# [env.staging]
+# route = "staging.acmcsuf.com/*"
+# workers_dev = false

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -5,7 +5,6 @@ name = "acmcsuf-com"
 main = ".svelte-kit/cloudflare/_worker.js"
 compatibility_date = "2026-01-04"
 compatibility_flags = [ "nodejs_als", "nodejs_compat" ]
-preview_urls = true
 
 [assets]
 binding = "ASSETS"
@@ -18,9 +17,16 @@ head_sampling_rate = 1
 invocation_logs = true
 persist = true
 
-[env.production]
-route = "acmcsuf.com"
-workers_dev = false
-
-[env.preview]
+# ==== Route/Domain Configuration ==================================================================
 workers_dev = true
+# https://developers.cloudflare.com/workers/configuration/previews/
+preview_urls = true  # To use: `wrangler versions upload -e [env-name]`
+
+# This uses vars defined in .env.production (make sure debug is off!)
+[env.production]
+routes = [
+  { pattern = "acmcsuf.com", custom_domain = true }
+]
+
+# More environments like [env.staging] can be created here, and they can be deployed
+# with `wrangler deploy -e staging` or whatever the env is called.


### PR DESCRIPTION
Instead of having two workers in the dashboard (acmcsuf-com-production and acmcsuf-com-preview), this simplifies things by removing the latter worker. `npm run preview` now uses a different command, `wrangler versions upload -e production` that deploys using the same configuration as deployments to the acmcsuf.com domain, but on a workers.dev domain with optional tag (see comment in wrangler.toml). View all deployments in the Deployments tab of the worker.