### PR TITLE
remove depreciated setting from `.npmrc`

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,1 @@
 engine-strict=true
-resolution-mode=highest

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
 engine-strict=true
+fund=false


### PR DESCRIPTION
`resolution-mode=highest` is a depreciated setting. This removes it and also adds the `fund=false` setting (hides the "packages looking for funding" message)