### PR TITLE
use cloudflare vite plugin to re-enable `vite dev`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "temporal-polyfill": "^0.3.0"
       },
       "devDependencies": {
+        "@cloudflare/vite-plugin": "^1.21.0",
         "@eslint/js": "^9.35.0",
         "@size-limit/file": "^8.2.6",
         "@sveltejs/adapter-auto": "^6.1.0",
@@ -79,6 +80,24 @@
         "workerd": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@cloudflare/vite-plugin": {
+      "version": "1.21.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/vite-plugin/-/vite-plugin-1.21.0.tgz",
+      "integrity": "sha512-3VXtkfjOQL+k3Plj+t0BHRyw8iIIRBQ8RJU6KJHJQKdYHA6rJE/WlSa/lRd0A8MMhvP8e8QiMLuDqveEN8gCZg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cloudflare/unenv-preset": "2.10.0",
+        "miniflare": "4.20260114.0",
+        "unenv": "2.0.0-rc.24",
+        "wrangler": "4.59.2",
+        "ws": "8.18.0"
+      },
+      "peerDependencies": {
+        "vite": "^6.1.0 || ^7.0.0",
+        "wrangler": "^4.59.2"
       }
     },
     "node_modules/@cloudflare/workerd-darwin-64": {

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "deploy": "vite build --mode production && wrangler deploy -e production"
   },
   "devDependencies": {
+    "@cloudflare/vite-plugin": "^1.21.0",
     "@eslint/js": "^9.35.0",
     "@size-limit/file": "^8.2.6",
     "@sveltejs/adapter-auto": "^6.1.0",

--- a/package.json
+++ b/package.json
@@ -29,9 +29,10 @@
   ],
   "scripts": {
     "start": "npm run dev",
-    "dev": "wrangler dev",
+    "dev": "vite dev",
     "build": "vite build",
-    "preview": "vite build -- mode production && wrangler versions upload -e production",
+    "preview": "wrangler dev",
+    "preview:live": "vite build -- mode production && wrangler versions upload -e production",
     "test": "vitest --run",
     "test:watch": "vitest",
     "test:size": "npm run build && size-limit",

--- a/package.json
+++ b/package.json
@@ -31,8 +31,9 @@
     "start": "npm run dev",
     "dev": "vite dev",
     "build": "vite build",
-    "preview": "wrangler dev",
-    "preview:live": "vite build -- mode production && wrangler versions upload -e production",
+    "build:prod": "CLOUDFLARE_ENV=production vite build",
+    "preview": "npm run build:prod && vite preview",
+    "preview:live": "npm run build:prod && wrangler versions upload",
     "test": "vitest --run",
     "test:watch": "vitest",
     "test:size": "npm run build && size-limit",
@@ -43,7 +44,7 @@
     "host": "npm run all && npm run preview",
     "all": "npm run lint && npm run format && npm run check && npm run build && npm t",
     "generate:colors": "node scripts/generate-colors/index.js",
-    "deploy": "vite build --mode production && wrangler deploy -e production"
+    "deploy": "npm run build:prod && wrangler deploy"
   },
   "devDependencies": {
     "@cloudflare/vite-plugin": "^1.21.0",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,8 +1,9 @@
 import { sveltekit } from '@sveltejs/kit/vite';
 import { defineConfig } from 'vitest/config';
+import { cloudflare } from '@cloudflare/vite-plugin';
 
 export default defineConfig({
-  plugins: [sveltekit()],
+  plugins: [sveltekit(), cloudflare()],
   test: {
     include: ['src/**/*.{test,spec}.{js,ts}'],
   },


### PR DESCRIPTION
When we migrated to workers, I changed the dev server command from `vite dev` to `wrangler dev` due to some inconsistencies between the vite dev server and production environment. However, we lose hot reloading with this change which is quite annoying.

The solution *appears* to be installing and using the official cloudflare vite plugin, which should give us the best of both worlds, and while using `vite dev` after installing works, `vite build` starts failing