### PR TITLE
Update Spring 2026 Board Officers

### DIFF
--- a/src/lib/public/board/data/officers.json
+++ b/src/lib/public/board/data/officers.json
@@ -602,10 +602,7 @@
         { "title": "Node Buds Team Lead", "tier": 34 }
       ],
       "F25": [{ "title": "Treasurer", "tier": 4 }],
-      "S26": [
-        { "title": "Treasurer", "tier": 4 },
-        { "title": "Design Officer", "tier": 16 }
-      ]
+      "S26": [{ "title": "Treasurer", "tier": 4 }]
     },
     "discord": "@evie724"
   },


### PR DESCRIPTION
I updated ``/teams`` for Spring 2026.
<img width="1890" height="910" alt="Screenshot 2026-02-03 064609" src="https://github.com/user-attachments/assets/a9420968-c256-4887-9538-2846dbd3a141" />
<img width="1885" height="910" alt="Screenshot 2026-02-03 064624" src="https://github.com/user-attachments/assets/5d175de8-0559-4a88-9717-55942499fca7" />

