### PR TITLE
Update Game Dev Board on /teams

### DIFF
--- a/src/lib/public/board/data/officers.json
+++ b/src/lib/public/board/data/officers.json
@@ -1716,8 +1716,7 @@
     "fullName": "Alessandro Garcia",
     "picture": "alessandro-garcia.webp",
     "positions": {
-      "F25": [{ "title": "Game Dev Officer", "tier": 23 }],
-      "S26": [{ "title": "Game Dev Officer", "tier": 23 }]
+      "F25": [{ "title": "Game Dev Officer", "tier": 23 }]
     },
     "discord": "@acczelzz"
   },
@@ -1737,10 +1736,7 @@
         { "title": "Game Dev Officer", "tier": 23 },
         { "title": "Algo Officer", "tier": 12 }
       ],
-      "S26": [
-        { "title": "Game Dev Officer", "tier": 23 },
-        { "title": "Algo Officer", "tier": 12 }
-      ]
+      "S26": [{ "title": "Algo Officer", "tier": 12 }]
     },
     "discord": "@bald0398"
   },


### PR DESCRIPTION
I updated the Game Dev board for Spring 2026 on ``/teams``.
<img width="1880" height="987" alt="image" src="https://github.com/user-attachments/assets/ab3e75d3-26be-4fcc-9436-edfb7f3b851a" />
