### PR TITLE
Update Spring 2026 Board Officers

### DIFF
--- a/src/lib/public/board/data/officers.json
+++ b/src/lib/public/board/data/officers.json
@@ -969,10 +969,7 @@
         { "title": "AI Team Lead", "tier": 20 },
         { "title": "Algo Officer", "tier": 12 }
       ],
-      "S26": [
-        { "title": "AI Team Lead", "tier": 20 },
-        { "title": "Algo Officer", "tier": 12 }
-      ]
+      "S26": [{ "title": "AI Team Lead", "tier": 20 }]
     },
     "discord": "@josu4412"
   },
@@ -1707,8 +1704,7 @@
     "fullName": "John Alora",
     "picture": "john-alora.webp",
     "positions": {
-      "F25": [{ "title": "Game Dev Officer", "tier": 23 }],
-      "S26": [{ "title": "Game Dev Officer", "tier": 23 }]
+      "F25": [{ "title": "Game Dev Officer", "tier": 23 }]
     },
     "discord": "@cedrix"
   },


### PR DESCRIPTION
I updated the board officers on ``/teams`` for the Spring 2026 term.
<img width="1876" height="987" alt="Screenshot 2026-02-05 102809" src="https://github.com/user-attachments/assets/a46f7636-4dcd-4ea5-8775-34b5d107591a" />
<img width="1876" height="988" alt="Screenshot 2026-02-05 102830" src="https://github.com/user-attachments/assets/36a35406-48a5-47f6-9151-2958226bfcd6" />
<img width="1876" height="984" alt="Screenshot 2026-02-05 102844" src="https://github.com/user-attachments/assets/6e7c0dac-1a8c-4e3b-bb54-c8d0e484e5f2" />
