### PR TITLE
Update Dev Board on /teams for Spring 2026

### DIFF
--- a/src/lib/public/board/data/officers.json
+++ b/src/lib/public/board/data/officers.json
@@ -1167,8 +1167,7 @@
     "positions": {
       "F24": [{ "title": "AI Officer", "tier": 21 }],
       "S25": [{ "title": "AI Officer", "tier": 21 }],
-      "F25": [{ "title": "Dev Officer", "tier": 19 }],
-      "S26": [{ "title": "Dev Officer", "tier": 19 }]
+      "F25": [{ "title": "Dev Officer", "tier": 19 }]
     },
     "discord": "@kenny8092"
   },


### PR DESCRIPTION
I updated the Dev Board on ``/teams`` for the Spring 2026 term.
<img width="1892" height="911" alt="image" src="https://github.com/user-attachments/assets/b7d6a1d4-b908-4f8d-9f55-e4ee0fbf551a" />
