### PR TITLE
Update Spring 2026 Board Officers

### DIFF
--- a/src/lib/public/board/data/officers.json
+++ b/src/lib/public/board/data/officers.json
@@ -1405,8 +1405,7 @@
     "picture": "ender-batu.webp",
     "positions": {
       "S25": [{ "title": "AI Officer", "tier": 21 }],
-      "F25": [{ "title": "AI Officer", "tier": 21 }],
-      "S26": [{ "title": "AI Officer", "tier": 21 }]
+      "F25": [{ "title": "AI Officer", "tier": 21 }]
     },
     "discord": "@rothchild"
   },
@@ -1694,8 +1693,7 @@
     "fullName": "Maverick Malfavon",
     "picture": "maverick-malfavon.webp",
     "positions": {
-      "F25": [{ "title": "Game Dev Officer", "tier": 23 }],
-      "S26": [{ "title": "Game Dev Officer", "tier": 23 }]
+      "F25": [{ "title": "Game Dev Officer", "tier": 23 }]
     },
     "discord": "@mavreal"
   },


### PR DESCRIPTION
I updated AI and Game Dev's officers on ``/teams`` for Spring 2026.
<img width="1892" height="909" alt="Screenshot 2026-02-14 125627" src="https://github.com/user-attachments/assets/88605539-d639-4581-9637-887f7a1273a5" />
<img width="1888" height="910" alt="Screenshot 2026-02-14 125639" src="https://github.com/user-attachments/assets/e1ffe796-1e68-470c-b078-5beb4f3ef952" />
