### PR TITLE
Update Spring 2026 Board Officers for Dev Team on /teams

### DIFF
--- a/src/lib/public/board/data/officers.json
+++ b/src/lib/public/board/data/officers.json
@@ -1331,8 +1331,7 @@
     "picture": "talhah-raheem.webp",
     "positions": {
       "S25": [{ "title": "Dev Officer", "tier": 19 }],
-      "F25": [{ "title": "Dev Officer", "tier": 19 }],
-      "S26": [{ "title": "Dev Officer", "tier": 19 }]
+      "F25": [{ "title": "Dev Officer", "tier": 19 }]
     },
     "discord": "@arrow5566"
   },


### PR DESCRIPTION
I updated the Dev Board for Spring 2026 on ``/teams``
<img width="1888" height="909" alt="image" src="https://github.com/user-attachments/assets/5a2f90e7-bc83-4027-81eb-2273d0971a8e" />
