### PR TITLE
Update Spring 2026 Board Officers on /teams

### DIFF
--- a/src/lib/public/board/data/officers.json
+++ b/src/lib/public/board/data/officers.json
@@ -1727,8 +1727,7 @@
       "F25": [
         { "title": "Game Dev Officer", "tier": 23 },
         { "title": "Algo Officer", "tier": 12 }
-      ],
-      "S26": [{ "title": "Algo Officer", "tier": 12 }]
+      ]
     },
     "discord": "@bald0398"
   },


### PR DESCRIPTION
I updated Algo's board officers on ``/teams`` for the Spring 2026 term.
<img width="1892" height="910" alt="image" src="https://github.com/user-attachments/assets/15c66b63-6156-4f20-8952-ca1d27a8d5bc" />
