### PR TITLE
Removed Unused CSS Selector

### DIFF
--- a/src/routes/(site)/teams/+page.svelte
+++ b/src/routes/(site)/teams/+page.svelte
@@ -312,28 +312,6 @@
     filter: brightness(90%);
   }
 
-  @media (prefers-color-scheme: dark) {
-    [data-theme='dark'] section .team-icons-inner-container .ai :hover {
-      cursor: pointer;
-      transform: scale(1.07);
-      filter: brightness(105%);
-    }
-
-    [data-theme='dark'] section .team-icons-inner-container a :hover {
-      cursor: pointer;
-      transform: scale(1.07);
-      filter: brightness(110%);
-    }
-
-    [data-theme='dark'] section .team-icons-inner-container .icon .ai :active {
-      filter: brightness(110%);
-    }
-
-    [data-theme='dark'] section .team-icons-inner-container .icon a :active {
-      filter: brightness(120%);
-    }
-  }
-
   section .team-icons-inner-container .icon a img {
     width: 100%;
     height: auto;


### PR DESCRIPTION
I deleted the unused CSS selectors in ``src/routes/(site)/teams/+page.svelte``, so now it no longer shows warnings when ``npm run build`` is run. This solves #1233. 